### PR TITLE
Seção [Usuários] - Redefinição de Senha - Pedido de Redefinição Integração ao Backend (4/4)

### DIFF
--- a/src/app/api/user/password-reset/route.ts
+++ b/src/app/api/user/password-reset/route.ts
@@ -1,0 +1,39 @@
+import { auth } from '@/auth'
+import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import { PostUserPasswordResetFactory } from '@/modules/users/infrastructure/factories/post-user-password-reset.factory'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  const { token } = await auth()
+  const postUserFactory = PostUserPasswordResetFactory.create()
+  const userPasswordReset = await req.json()
+  try {
+    await postUserFactory.execute(token, userPasswordReset)
+    return NextResponse.json(
+      {
+        success: true
+      },
+      { status: Number(HttpStatusCodeEnum.OK) }
+    )
+  } catch (error) {
+    if (error instanceof HttpResponseError) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          message: error.message
+        },
+        { status: Number(HttpStatusCodeEnum.BAD_REQUEST) }
+      )
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        message: 'Erro inesperado'
+      },
+      { status: Number(HttpStatusCodeEnum.INTERNAL_SERVER_ERROR) }
+    )
+  }
+}

--- a/src/modules/api/domain/interfaces/post-user-password-reset-router-api-service.interface.ts
+++ b/src/modules/api/domain/interfaces/post-user-password-reset-router-api-service.interface.ts
@@ -1,0 +1,5 @@
+import type { UserPasswordResetInterface } from '@/modules/users/domain/interfaces/user-password-reset.interface'
+
+export interface PostUserPasswordResetRouterApiServiceInterface {
+  execute(userPasswordReset: UserPasswordResetInterface): Promise<void>
+}

--- a/src/modules/api/infrastructure/factories/post-user-password-reset-router-api.factory.ts
+++ b/src/modules/api/infrastructure/factories/post-user-password-reset-router-api.factory.ts
@@ -1,0 +1,12 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import { PostUserPasswordResetRouterApiService } from '../services/post-user-password-reset-router-api.service'
+import type { PostUserPasswordResetRouterApiServiceInterface } from '../../domain/interfaces/post-user-password-reset-router-api-service.interface'
+
+export class PostUserPasswordResetRouterApiFactory {
+  static create(): PostUserPasswordResetRouterApiServiceInterface {
+    const httpClient = HttpClientFactory.create('/')
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new PostUserPasswordResetRouterApiService(executeRequest)
+  }
+}

--- a/src/modules/api/infrastructure/services/post-user-password-reset-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/post-user-password-reset-router-api.service.ts
@@ -1,0 +1,28 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { PostUserPasswordResetRouterApiServiceInterface } from '../../domain/interfaces/post-user-password-reset-router-api-service.interface'
+import type { UserPasswordResetInterface } from '@/modules/users/domain/interfaces/user-password-reset.interface'
+import { HttpResponseUserPasswordResetValidator } from '@/modules/users/domain/validators/http-response-user-password-reset.validator'
+
+export class PostUserPasswordResetRouterApiService
+  implements PostUserPasswordResetRouterApiServiceInterface
+{
+  constructor(private readonly executeRequest: ExecuteRequest) {}
+
+  getHttpRequestConfig(
+    userPasswordReset: UserPasswordResetInterface
+  ): HttpRequestConfig<UserPasswordResetInterface> {
+    return {
+      method: 'POST',
+      data: userPasswordReset,
+      url: 'api/user/password-reset'
+    }
+  }
+
+  async execute(userPasswordReset: UserPasswordResetInterface): Promise<void> {
+    const settingsAuthHTTP = this.getHttpRequestConfig(userPasswordReset)
+    const { success, status } =
+      await this.executeRequest.execute<null>(settingsAuthHTTP)
+    HttpResponseUserPasswordResetValidator.validate(success, status)
+  }
+}

--- a/src/modules/users/domain/interfaces/post-user-password-reset-service.interface.ts
+++ b/src/modules/users/domain/interfaces/post-user-password-reset-service.interface.ts
@@ -1,0 +1,9 @@
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { UserPasswordResetInterface } from './user-password-reset.interface'
+
+export interface PostUserPasswordResetServiceInterface {
+  execute(
+    token: TokenEntities,
+    userPasswordReset: UserPasswordResetInterface
+  ): Promise<void>
+}

--- a/src/modules/users/domain/validators/http-response-user-password-reset.validator.ts
+++ b/src/modules/users/domain/validators/http-response-user-password-reset.validator.ts
@@ -1,0 +1,11 @@
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
+
+export class HttpResponseUserPasswordResetValidator {
+  static validate(success: boolean, status: string): void {
+    const isValidStatus = status === HttpStatusCodeEnum.OK
+    if (!success || !isValidStatus) {
+      throw new HttpResponseError(status)
+    }
+  }
+}

--- a/src/modules/users/infrastructure/factories/post-user-password-reset.factory.ts
+++ b/src/modules/users/infrastructure/factories/post-user-password-reset.factory.ts
@@ -1,0 +1,14 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import type { PostUserPasswordResetServiceInterface } from '../../domain/interfaces/post-user-password-reset-service.interface'
+import { PostUserPasswordResetService } from '../services/post-user-password-reset.service'
+import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
+
+export class PostUserPasswordResetFactory {
+  static create(): PostUserPasswordResetServiceInterface {
+    const httpClient = HttpClientFactory.create(process.env.HOST_API)
+    const formDataConvert = FormDataConverterFactory.create()
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new PostUserPasswordResetService(executeRequest, formDataConvert)
+  }
+}

--- a/src/modules/users/infrastructure/services/post-user-password-reset.service.ts
+++ b/src/modules/users/infrastructure/services/post-user-password-reset.service.ts
@@ -1,0 +1,52 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { PostUserPasswordResetServiceInterface } from '../../domain/interfaces/post-user-password-reset-service.interface'
+
+import type { UserPasswordResetInterface } from '../../domain/interfaces/user-password-reset.interface'
+import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
+import { HttpResponseUserPasswordResetValidator } from '../../domain/validators/http-response-user-password-reset.validator'
+
+export class PostUserPasswordResetService
+  implements PostUserPasswordResetServiceInterface
+{
+  constructor(
+    private readonly executeRequest: ExecuteRequest,
+    private readonly convertFormData: ConvertJsonToFormData
+  ) {}
+
+  getHttpRequestConfig(
+    token: TokenEntities,
+    userPasswordReset: FormData
+  ): HttpRequestConfig<FormData> {
+    return {
+      method: 'POST',
+      url: `/users/password-resets`,
+      data: userPasswordReset,
+      headers: token.access_token && {
+        Authorization: `${token.token_type} ${token.access_token}`
+      }
+    }
+  }
+
+  async execute(
+    token: TokenEntities,
+    userPasswordReset: UserPasswordResetInterface
+  ): Promise<void> {
+    const enrichedUserPasswordReset = {
+      user_id: userPasswordReset.userId,
+      days_passwd_reg_deadline: userPasswordReset.days_passwd_reg_deadline
+    }
+    const userPasswordResetFormDataConverted = this.convertFormData.execute({
+      ...enrichedUserPasswordReset
+    })
+    const settingsAuthHTTP = this.getHttpRequestConfig(
+      token,
+      userPasswordResetFormDataConverted
+    )
+    const { success, status }: HttpResponse<null> =
+      await this.executeRequest.execute(settingsAuthHTTP)
+    HttpResponseUserPasswordResetValidator.validate(success, status)
+  }
+}

--- a/src/modules/users/presentation/hooks/use-update-user-password-reset-submit.hook.ts
+++ b/src/modules/users/presentation/hooks/use-update-user-password-reset-submit.hook.ts
@@ -3,9 +3,11 @@ import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
 import { useUserStore } from '../stores/user.store'
 import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
 import type { UserPasswordResetInterface } from '../../domain/interfaces/user-password-reset.interface'
+import { useUserPasswordResetStore } from '../stores/user-password-reset.store'
 
 export function usePutUserPasswordResetSubmit() {
   const { getUsers } = useUserStore()
+  const { solicitedNewPassword } = useUserPasswordResetStore()
 
   const onAction = useCallback(
     async (
@@ -13,19 +15,21 @@ export function usePutUserPasswordResetSubmit() {
       onSuccess: VoidFunction
     ): Promise<void> => {
       try {
+        await solicitedNewPassword(userPasswordReset)
         await getUsers()
         toast({
-          title: 'Usuário atualizado com sucesso!',
+          title: 'Redefinição de senha enviada com sucesso!',
           variant: 'success',
-          description: JSON.stringify(userPasswordReset)
+          description:
+            'Verifique o e-mail do usuário selecionado, siga as instruções para redefinir a senha.'
         })
         onSuccess?.()
       } catch (error) {
         if (error instanceof HttpResponseError) {
           toast({
-            title: 'Erro ao atualizar usuário',
+            title: 'Erro ao redefinir a senha',
             description:
-              'Ocorreu um problema ao tentar atualizar o usuário. Verifique e tente novamente',
+              'Ocorreu um problema ao tentar solicitar a redefinição de senha. Verifique e tente novamente',
             variant: 'destructive'
           })
         }

--- a/src/modules/users/presentation/stores/user-password-reset.store.ts
+++ b/src/modules/users/presentation/stores/user-password-reset.store.ts
@@ -1,0 +1,26 @@
+import { create } from 'zustand'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import type { UserPasswordResetInterface } from '../../domain/interfaces/user-password-reset.interface'
+import { PostUserPasswordResetRouterApiFactory } from '@/modules/api/infrastructure/factories/post-user-password-reset-router-api.factory'
+
+type UserPasswordResetState = {
+  solicitedNewPassword: (
+    userPasswordReset: UserPasswordResetInterface
+  ) => Promise<void>
+}
+
+export const useUserPasswordResetStore = create<UserPasswordResetState>(() => ({
+  solicitedNewPassword: async (
+    userPasswordReset: UserPasswordResetInterface
+  ) => {
+    try {
+      const postUserPasswordResetRouterApiFactory =
+        PostUserPasswordResetRouterApiFactory.create()
+      await postUserPasswordResetRouterApiFactory.execute(userPasswordReset)
+    } catch (error) {
+      if (error instanceof HttpResponseError) {
+        throw error
+      }
+    }
+  }
+}))


### PR DESCRIPTION
**Descrição:**

Foi adicionado integração do backend ao formulário de solicitação de redefinição de senha.

**Alterações:**

- **Adicionado:**
  - Endpoint de redefinição de senha para Router API do nextJS
  - Fabrica de construção do serviço de redefinição de senha (Router API)
  - Serviço de redefinição de senha (Router API)
  - Interface de serviço de redefinição de senha (Router API)
  - Fabrica de construção do serviço de redefinição de senha (Backend)
  - Serviço de redefinição de senha (Backend)
  - Interface de serviço de redefinição de senha (Backend)
  - Validador de requisição http para o response
  - Injeção da store de redefinição de senha ao hook
 