### PR TITLE
Seção [Usuários] - Redefinição de Senha - Nova Senha Integração ao Backend (2/4)

### DIFF
--- a/src/app/api/password-reset/route.ts
+++ b/src/app/api/password-reset/route.ts
@@ -1,0 +1,37 @@
+import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
+import { PutPasswordResetFactory } from '@/modules/password-reset/infrastructure/factories/put-password-reset.factory'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import { NextRequest, NextResponse } from 'next/server'
+
+export async function PUT(req: NextRequest): Promise<NextResponse> {
+  const putPasswordResetFactory = PutPasswordResetFactory.create()
+  const { token, newPassword } = await req.json()
+  try {
+    await putPasswordResetFactory.execute({ token, newPassword })
+    return NextResponse.json(
+      {
+        success: true
+      },
+      { status: Number(HttpStatusCodeEnum.OK) }
+    )
+  } catch (error) {
+    if (error instanceof HttpResponseError) {
+      return NextResponse.json(
+        {
+          success: false,
+          data: null,
+          message: error.message
+        },
+        { status: Number(HttpStatusCodeEnum.BAD_REQUEST) }
+      )
+    }
+    return NextResponse.json(
+      {
+        success: false,
+        data: null,
+        message: 'Erro inesperado'
+      },
+      { status: Number(HttpStatusCodeEnum.INTERNAL_SERVER_ERROR) }
+    )
+  }
+}

--- a/src/app/authentication/password-reset/[token]/page.tsx
+++ b/src/app/authentication/password-reset/[token]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { use } from 'react'
-import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset.interface'
+import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset-form.interface'
 import { PasswordResetCard } from '@/modules/password-reset/presentation/components/password-reset-card'
 import { PasswordResetForm } from '@/modules/password-reset/presentation/components/password-reset-form'
 import { PasswordResetFormCard } from '@/modules/password-reset/presentation/components/password-reset-form-card'

--- a/src/modules/api/domain/interfaces/put-password-reset-router-api.interface.ts
+++ b/src/modules/api/domain/interfaces/put-password-reset-router-api.interface.ts
@@ -1,0 +1,5 @@
+import type { PasswordResetInterface } from '@/modules/password-reset/domain/interfaces/password-reset.interface'
+
+export interface PutPasswordResetRouterApiServiceInterface {
+  execute({ token, newPassword }: PasswordResetInterface): Promise<void>
+}

--- a/src/modules/api/infrastructure/factories/put-password-reset-router-api.factory.ts
+++ b/src/modules/api/infrastructure/factories/put-password-reset-router-api.factory.ts
@@ -1,0 +1,12 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import { PutPasswordResetRouterApiService } from '../services/put-password-reset-router-api.service'
+import type { PutPasswordResetRouterApiServiceInterface } from '../../domain/interfaces/put-password-reset-router-api.interface'
+
+export class PutPasswordResetRouterApiFactory {
+  static create(): PutPasswordResetRouterApiServiceInterface {
+    const httpClient = HttpClientFactory.create('/')
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new PutPasswordResetRouterApiService(executeRequest)
+  }
+}

--- a/src/modules/api/infrastructure/services/put-password-reset-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/put-password-reset-router-api.service.ts
@@ -1,0 +1,29 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { PutPasswordResetRouterApiServiceInterface } from '../../domain/interfaces/put-password-reset-router-api.interface'
+import { HttpResponsePasswordResetValidator } from '@/modules/password-reset/domain/validators/http-response-password-reset.validator'
+import type { PasswordResetInterface } from '@/modules/password-reset/domain/interfaces/password-reset.interface'
+
+export class PutPasswordResetRouterApiService
+  implements PutPasswordResetRouterApiServiceInterface
+{
+  constructor(private readonly executeRequest: ExecuteRequest) {}
+
+  getHttpRequestConfig({
+    token,
+    newPassword
+  }: PasswordResetInterface): HttpRequestConfig {
+    return {
+      method: 'PUT',
+      data: { token, newPassword },
+      url: 'api/password-reset'
+    }
+  }
+
+  async execute({ token, newPassword }: PasswordResetInterface): Promise<void> {
+    const settingsAuthHTTP = this.getHttpRequestConfig({ token, newPassword })
+    const { success, status } =
+      await this.executeRequest.execute(settingsAuthHTTP)
+    HttpResponsePasswordResetValidator.validate(success, status)
+  }
+}

--- a/src/modules/password-reset/domain/interfaces/password-reset-form.interface.ts
+++ b/src/modules/password-reset/domain/interfaces/password-reset-form.interface.ts
@@ -1,0 +1,4 @@
+export interface PasswordResetFormInterface {
+  newPassword: string
+  passwordConfirm: string
+}

--- a/src/modules/password-reset/domain/interfaces/password-reset.interface.ts
+++ b/src/modules/password-reset/domain/interfaces/password-reset.interface.ts
@@ -1,4 +1,7 @@
-export interface PasswordResetFormInterface {
-  newPassword: string
-  passwordConfirm: string
+import type { TokenEntities } from "@/modules/authentication/domain/entities/token.entity"
+import type { PasswordResetFormInterface } from "./password-reset-form.interface"
+
+export interface PasswordResetInterface {
+  token: TokenEntities['access_token']
+  newPassword: PasswordResetFormInterface['newPassword']
 }

--- a/src/modules/password-reset/domain/interfaces/put-password-reset-service.interface.ts
+++ b/src/modules/password-reset/domain/interfaces/put-password-reset-service.interface.ts
@@ -1,0 +1,5 @@
+import type { PasswordResetInterface } from './password-reset.interface'
+
+export interface PutPasswordResetServiceInterface {
+  execute({ token, newPassword }: PasswordResetInterface): Promise<void>
+}

--- a/src/modules/password-reset/domain/validators/http-response-password-reset.validator.ts
+++ b/src/modules/password-reset/domain/validators/http-response-password-reset.validator.ts
@@ -1,0 +1,10 @@
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
+
+export class HttpResponsePasswordResetValidator {
+  static validate(success: boolean, status: string): void {
+    if (!success || status !== HttpStatusCodeEnum.OK) {
+      throw new HttpResponseError(status)
+    }
+  }
+}

--- a/src/modules/password-reset/infrastructure/factories/put-password-reset.factory.ts
+++ b/src/modules/password-reset/infrastructure/factories/put-password-reset.factory.ts
@@ -1,0 +1,14 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import { PutPasswordResetService } from '../services/put-password-reset.service'
+import type { PutPasswordResetServiceInterface } from '../../domain/interfaces/put-password-reset-service.interface'
+import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
+
+export class PutPasswordResetFactory {
+  static create(): PutPasswordResetServiceInterface {
+    const httpClient = HttpClientFactory.create(process.env.HOST_API)
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    const formDataConvert = FormDataConverterFactory.create()
+    return new PutPasswordResetService(executeRequest, formDataConvert)
+  }
+}

--- a/src/modules/password-reset/infrastructure/services/put-password-reset.service.ts
+++ b/src/modules/password-reset/infrastructure/services/put-password-reset.service.ts
@@ -1,0 +1,44 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import { HttpResponsePasswordResetValidator } from '../../domain/validators/http-response-password-reset.validator'
+import type { PutPasswordResetServiceInterface } from '../../domain/interfaces/put-password-reset-service.interface'
+import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
+import type { PasswordResetInterface } from '../../domain/interfaces/password-reset.interface'
+
+export class PutPasswordResetService
+  implements PutPasswordResetServiceInterface
+{
+  constructor(
+    private readonly executeRequest: ExecuteRequest,
+    private readonly convertFormData: ConvertJsonToFormData
+  ) {}
+
+  getHttpRequestConfig(
+    passwordResetWithToken: FormData
+  ): HttpRequestConfig<FormData> {
+    return {
+      method: 'PUT',
+      url: `/users/password-resets`,
+      data: passwordResetWithToken
+    }
+  }
+
+  async execute({
+    token,
+    newPassword
+  }: PasswordResetInterface): Promise<void> {
+    const enrichedPasswordReset = {
+      token: token,
+      new_password: newPassword
+    }
+    const passwordResetWithTokenConverted = this.convertFormData.execute(
+      enrichedPasswordReset
+    )
+    const settingsAuthHTTP = this.getHttpRequestConfig(
+      passwordResetWithTokenConverted
+    )
+    const { success, status } =
+      await this.executeRequest.execute(settingsAuthHTTP)
+    HttpResponsePasswordResetValidator.validate(success, status)
+  }
+}

--- a/src/modules/password-reset/presentation/components/password-reset-form-provider/password-reset-form-provider.component.tsx
+++ b/src/modules/password-reset/presentation/components/password-reset-form-provider/password-reset-form-provider.component.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 import { zodResolver } from '@hookform/resolvers/zod'
 import type { ReactNode } from 'react'
 import { PasswordResetFormSchema } from '../../schemas/password-reset-form.schema'
-import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset.interface'
+import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset-form.interface'
 
 interface PasswordResetFormContextProviderComponentProps {
   children: ReactNode

--- a/src/modules/password-reset/presentation/components/password-reset-form/password-reset-form-submit.component.tsx
+++ b/src/modules/password-reset/presentation/components/password-reset-form/password-reset-form-submit.component.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset.interface'
+import type { PasswordResetFormInterface } from '@/modules/password-reset/domain/interfaces/password-reset-form.interface'
 import { Button } from '@/modules/shared/presentation/components/shadcn/button'
 import { useFormContext } from 'react-hook-form'
 

--- a/src/modules/password-reset/presentation/hooks/password-reset-submit.hook.tsx
+++ b/src/modules/password-reset/presentation/hooks/password-reset-submit.hook.tsx
@@ -1,19 +1,39 @@
 import { useCallback } from 'react'
 import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
-import type { PasswordResetFormInterface } from '../../domain/interfaces/password-reset.interface'
+import type { PasswordResetFormInterface } from '../../domain/interfaces/password-reset-form.interface'
+import { usePasswordResetStore } from '../stores/password-reset.store'
+import { redirect } from 'next/navigation'
+import { PATHNAMES } from '@/modules/shared/infrastructure/configs/pathnames.config'
 
 export function usePasswordResetSubmit() {
+  const { updatePasswordReset } = usePasswordResetStore()
+
   const onAction = useCallback(
-    (
-      { newPassword: new_password }: PasswordResetFormInterface,
+    async (
+      { newPassword }: PasswordResetFormInterface,
       token: string
-    ): void => {
-      toast({
-        title: 'Senha atualizada com sucesso!',
-        description: JSON.stringify({ new_password, token })
-      })
+    ): Promise<void> => {
+      try {
+        await updatePasswordReset({ token, newPassword })
+        toast({
+          title: 'Senha atualizada com sucesso!',
+          description:
+            'Em segundos será redirecionado para a seção de autenticação',
+          variant: 'success'
+        })
+        setTimeout(() => {
+          redirect(PATHNAMES.AUTHENTICATION)
+        }, 1000)
+      } catch (error) {
+        toast({
+          title: 'Erro ao atualizar senha',
+          description:
+            'Verifique os dados do formulário ou solicite nova redefinição de senha.',
+          variant: 'destructive'
+        })
+      }
     },
-    []
+    [updatePasswordReset]
   )
 
   return { onAction }

--- a/src/modules/password-reset/presentation/schemas/password-reset-form.schema.ts
+++ b/src/modules/password-reset/presentation/schemas/password-reset-form.schema.ts
@@ -1,6 +1,6 @@
 import { MESSAGES_PASSWORD_RESET } from '@/modules/shared/presentation/messages/password-reset'
 import { z } from 'zod'
-import type { PasswordResetFormInterface } from '../../domain/interfaces/password-reset.interface'
+import type { PasswordResetFormInterface } from '../../domain/interfaces/password-reset-form.interface'
 
 export const PasswordResetFormSchema = z
   .object({

--- a/src/modules/password-reset/presentation/stores/password-reset.store.ts
+++ b/src/modules/password-reset/presentation/stores/password-reset.store.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand'
+import { PutPasswordResetRouterApiFactory } from '@/modules/api/infrastructure/factories/put-password-reset-router-api.factory'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import type { PasswordResetInterface } from '../../domain/interfaces/password-reset.interface'
+
+type PasswordResetState = {
+  updatePasswordReset: ({
+    token,
+    newPassword
+  }: PasswordResetInterface) => Promise<void>
+}
+
+export const usePasswordResetStore = create<PasswordResetState>(() => ({
+  updatePasswordReset: async ({
+    token,
+    newPassword
+  }: PasswordResetInterface) => {
+    try {
+      const putPasswordResetRouterApiFactory =
+        PutPasswordResetRouterApiFactory.create()
+      await putPasswordResetRouterApiFactory.execute({ token, newPassword })
+    } catch (error) {
+      if (error instanceof HttpResponseError) {
+        throw error
+      }
+    }
+  }
+}))


### PR DESCRIPTION
**Descrição:**

Foi adicionado integração do backend a pagina com o formulário de redefinição de senha.

**Alterações:**

- **Adicionado:**
  - Endpoint de redefinição de senha para Router API do nextJS
  - Fabrica de construção do serviço de redefinição de senha (Router API)
  - Serviço de redefinição de senha (Router API)
  - Interface de serviço de redefinição de senha (Router API)
  - Fabrica de construção do serviço de redefinição de senha (Backend)
  - Serviço de redefinição de senha (Backend)
  - Interface de serviço de redefinição de senha (Backend)
  - Validador de requisição http para o response
  - Injeção da store de redefinição de senha ao hook
 