### PR TITLE
Seção [Perfis de Permissão] - Listagem de Perfis de Permissão de Usuário (2/N)

### DIFF
--- a/src/app/api/user/[userId]/permission-profile/route.ts
+++ b/src/app/api/user/[userId]/permission-profile/route.ts
@@ -1,0 +1,35 @@
+import { auth } from '@/auth'
+import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import type { UserEntity } from '@/modules/users/domain/entities/user.entity'
+import { GetUserWithPermissionProfileFactory } from '@/modules/users/infrastructure/factories/get-user-with-permission-profile.factory'
+import { NextResponse, type NextRequest } from 'next/server'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ userId: UserEntity['id'] }> }
+): Promise<NextResponse> {
+  try {
+    const { userId } = await params
+    const { token } = await auth()
+    const getUserWithPermissionProfileFactory =
+      GetUserWithPermissionProfileFactory.create()
+    const response = await getUserWithPermissionProfileFactory.execute(
+      token,
+      userId
+    )
+    return NextResponse.json(response, {
+      status: Number(HttpStatusCodeEnum.OK)
+    })
+  } catch (error) {
+    if (error instanceof HttpResponseError) {
+      return NextResponse.json(
+        {
+          success: false,
+          message: error.message
+        },
+        { status: Number(HttpStatusCodeEnum.BAD_REQUEST) }
+      )
+    }
+  }
+}

--- a/src/app/system/operations/users/page.tsx
+++ b/src/app/system/operations/users/page.tsx
@@ -15,6 +15,8 @@ import { ViewMoreUserMenuComponent } from '@/modules/users/presentation/componen
 import { PutUserPasswordResetMenuComponent } from '@/modules/users/presentation/components/put-user-password-reset-menu/put-user-password-reset-menu.component'
 import { PutUserPasswordResetMenu } from '@/modules/users/presentation/components/put-user-password-reset-menu'
 import { MESSAGES_PASSWORD_RESET } from '@/modules/shared/presentation/messages/password-reset'
+import { BindUserWithPermissionProfilesMenuComponent } from '@/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu.component'
+import { BindUserWithPermissionProfilesMenu } from '@/modules/users/presentation/components/bind-user-with-permission-profiles-menu'
 
 interface Data {
   title: string
@@ -27,6 +29,8 @@ interface Data {
   menuViewMoreUserDescription: string
   menuPasswordResetUserTitle: string
   menuPasswordResetUserDescription: string
+  menuBindUserWithPermissionProfilesTitle: string
+  menuBindUserWithPermissionProfilesDescription: string
 }
 
 export default function UsersPage() {
@@ -40,7 +44,10 @@ export default function UsersPage() {
     menuViewMoreUserTitle: MESSAGES_USERS['5.27'],
     menuViewMoreUserDescription: MESSAGES_USERS['5.28'],
     menuPasswordResetUserTitle: MESSAGES_PASSWORD_RESET['2.14'],
-    menuPasswordResetUserDescription: MESSAGES_PASSWORD_RESET['2.15']
+    menuPasswordResetUserDescription: MESSAGES_PASSWORD_RESET['2.15'],
+    menuBindUserWithPermissionProfilesTitle: MESSAGES_PASSWORD_RESET['2.16'],
+    menuBindUserWithPermissionProfilesDescription:
+      MESSAGES_PASSWORD_RESET['2.17']
   }
 
   return (
@@ -65,38 +72,49 @@ export default function UsersPage() {
         <TableUsers.Header />
         <TableUsers.Body>
           <TableUsers.Item>
-            <ViewMoreUserMenu.Provider>
-              <EditUserMenu.Provider>
-                <PutUserPasswordResetMenu.Provider>
-                  <UserOptionsDropdown.Root>
-                    <UserOptionsDropdown.Trigger />
-                    <UserOptionsDropdown.Menu>
-                      <UserOptionsDropdown.Item>
-                        <EditUserMenu.Trigger />
-                      </UserOptionsDropdown.Item>
-                      <UserOptionsDropdown.Item>
-                        <ViewMoreUserMenu.Trigger />
-                      </UserOptionsDropdown.Item>
-                      <UserOptionsDropdown.Item>
-                        <PutUserPasswordResetMenu.Trigger />
-                      </UserOptionsDropdown.Item>
-                    </UserOptionsDropdown.Menu>
-                  </UserOptionsDropdown.Root>
-                  <ViewMoreUserMenuComponent
-                    title={data.menuViewMoreUserTitle}
-                    description={data.menuViewMoreUserDescription}
-                  />
-                  <PutUserPasswordResetMenuComponent
-                    title={data.menuPasswordResetUserTitle}
-                    description={data.menuPasswordResetUserDescription}
-                  />
-                  <EditUserMenuComponent
-                    title={data.menuEditUserTitle}
-                    description={data.menuEditUserDescription}
-                  />
-                </PutUserPasswordResetMenu.Provider>
-              </EditUserMenu.Provider>
-            </ViewMoreUserMenu.Provider>
+            <BindUserWithPermissionProfilesMenu.Provider>
+              <ViewMoreUserMenu.Provider>
+                <EditUserMenu.Provider>
+                  <PutUserPasswordResetMenu.Provider>
+                    <UserOptionsDropdown.Root>
+                      <UserOptionsDropdown.Trigger />
+                      <UserOptionsDropdown.Menu>
+                        <UserOptionsDropdown.Item>
+                          <ViewMoreUserMenu.Trigger />
+                        </UserOptionsDropdown.Item>
+                        <UserOptionsDropdown.Item>
+                          <EditUserMenu.Trigger />
+                        </UserOptionsDropdown.Item>
+                        <UserOptionsDropdown.Item>
+                          <BindUserWithPermissionProfilesMenu.Trigger />
+                        </UserOptionsDropdown.Item>
+                        <UserOptionsDropdown.Item>
+                          <PutUserPasswordResetMenu.Trigger />
+                        </UserOptionsDropdown.Item>
+                      </UserOptionsDropdown.Menu>
+                    </UserOptionsDropdown.Root>
+                    <BindUserWithPermissionProfilesMenuComponent
+                      title={data.menuBindUserWithPermissionProfilesTitle}
+                      description={
+                        data.menuBindUserWithPermissionProfilesDescription
+                      }
+                    />
+                    <ViewMoreUserMenuComponent
+                      title={data.menuViewMoreUserTitle}
+                      description={data.menuViewMoreUserDescription}
+                    />
+                    <PutUserPasswordResetMenuComponent
+                      title={data.menuPasswordResetUserTitle}
+                      description={data.menuPasswordResetUserDescription}
+                    />
+                    <EditUserMenuComponent
+                      title={data.menuEditUserTitle}
+                      description={data.menuEditUserDescription}
+                    />
+                  </PutUserPasswordResetMenu.Provider>
+                </EditUserMenu.Provider>
+              </ViewMoreUserMenu.Provider>
+            </BindUserWithPermissionProfilesMenu.Provider>
           </TableUsers.Item>
         </TableUsers.Body>
       </TableUsers.Root>

--- a/src/app/system/operations/users/page.tsx
+++ b/src/app/system/operations/users/page.tsx
@@ -45,9 +45,9 @@ export default function UsersPage() {
     menuViewMoreUserDescription: MESSAGES_USERS['5.28'],
     menuPasswordResetUserTitle: MESSAGES_PASSWORD_RESET['2.14'],
     menuPasswordResetUserDescription: MESSAGES_PASSWORD_RESET['2.15'],
-    menuBindUserWithPermissionProfilesTitle: MESSAGES_PASSWORD_RESET['2.16'],
+    menuBindUserWithPermissionProfilesTitle: MESSAGES_USERS['5.16'],
     menuBindUserWithPermissionProfilesDescription:
-      MESSAGES_PASSWORD_RESET['2.17']
+      MESSAGES_USERS['5.17']
   }
 
   return (

--- a/src/modules/api/domain/interfaces/get-user-with-permission-profile-router-api-service.interface.ts
+++ b/src/modules/api/domain/interfaces/get-user-with-permission-profile-router-api-service.interface.ts
@@ -1,0 +1,8 @@
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+import type { UserEntity } from '@/modules/users/domain/entities/user.entity'
+
+export interface GetUserWithPermissionProfileRouterApiServiceInterface {
+  execute(
+    userId: UserEntity['id']
+  ): Promise<PermissionProfileWithUserInterface[]>
+}

--- a/src/modules/api/infrastructure/factories/get-user-with-permission-profile-router-api.factory.ts
+++ b/src/modules/api/infrastructure/factories/get-user-with-permission-profile-router-api.factory.ts
@@ -1,0 +1,12 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import type { GetUserWithPermissionProfileRouterApiServiceInterface } from '../../domain/interfaces/get-user-with-permission-profile-router-api-service.interface'
+import { GetUserWithPermissionProfileRouterApiService } from '../services/get-user-with-permission-profile-router-api.service'
+
+export class GetUserWithPermissionProfileRouterApiFactory {
+  static create(): GetUserWithPermissionProfileRouterApiServiceInterface {
+    const httpClient = HttpClientFactory.create('/')
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new GetUserWithPermissionProfileRouterApiService(executeRequest)
+  }
+}

--- a/src/modules/api/infrastructure/services/get-user-with-permission-profile-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/get-user-with-permission-profile-router-api.service.ts
@@ -1,0 +1,33 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
+import type { UserEntity } from '../../../users/domain/entities/user.entity'
+import type { GetUserWithPermissionProfileRouterApiServiceInterface } from '../../domain/interfaces/get-user-with-permission-profile-router-api-service.interface'
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+import { HttpResponseUserValidator } from '@/modules/users/domain/validators/http-response-user.validator'
+
+export class GetUserWithPermissionProfileRouterApiService
+  implements GetUserWithPermissionProfileRouterApiServiceInterface
+{
+  constructor(private readonly executeRequest: ExecuteRequest) {}
+  getHttpRequestConfig(userId: UserEntity['id']): HttpRequestConfig {
+    return {
+      method: 'GET',
+      url: `api/user/${userId}/permission-profile`
+    }
+  }
+
+  async execute(
+    userId: UserEntity['id']
+  ): Promise<PermissionProfileWithUserInterface[]> {
+    const settingsAuthHTTP = this.getHttpRequestConfig(userId)
+    const {
+      success,
+      data,
+      status
+    }: HttpResponse<PermissionProfileWithUserInterface[]> =
+      await this.executeRequest.execute(settingsAuthHTTP)
+    HttpResponseUserValidator.validate(success, status)
+    return data
+  }
+}

--- a/src/modules/api/infrastructure/services/get-users-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/get-users-router-api.service.ts
@@ -20,7 +20,7 @@ export class GetUsersRouterApiService
     const settingsAuthHTTP = this.getHttpRequestConfig()
     const { success, data, status }: HttpResponse<UserEntity[]> =
       await this.executeRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
     return data
   }
 }

--- a/src/modules/api/infrastructure/services/post-user-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/post-user-router-api.service.ts
@@ -23,8 +23,8 @@ export class PostUserRouterApiService
   async execute(userWithFiles: UserWithFiles): Promise<void> {
     const userFormData = this.formData.execute(userWithFiles)
     const settingsAuthHTTP = this.getHttpRequestConfig(userFormData)
-    const { success, data, status } =
+    const { success, status } =
       await this.httpRequest.execute<null>(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
   }
 }

--- a/src/modules/api/infrastructure/services/put-user-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/put-user-router-api.service.ts
@@ -30,8 +30,8 @@ export class PutUserRouterApiService
       userWithFiles.id,
       userFormData
     )
-    const { success, data, status }: HttpResponse<null> =
+    const { success, status }: HttpResponse<null> =
       await this.httpRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
   }
 }

--- a/src/modules/permissions/domain/interfaces/permission-profile-with-user.interface.ts
+++ b/src/modules/permissions/domain/interfaces/permission-profile-with-user.interface.ts
@@ -1,0 +1,5 @@
+export interface PermissionProfileWithUserInterface {
+  id: number
+  user_id: number
+  perm_profile_id: number
+}

--- a/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-features.component.tsx
+++ b/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-features.component.tsx
@@ -63,7 +63,11 @@ export function PermissionProfileFormInputFeaturesComponent({
                     messageEmpty={MESSAGES_PERMISSIONS[6.6]}
                   >
                     {(item) => (
-                      <GroupSelector.Item item={item} id={item.id}>
+                      <GroupSelector.Item
+                        key={item.id}
+                        item={item}
+                        id={item.id}
+                      >
                         {({ selected }) => (
                           <div
                             className="flex items-center gap-x-4 w-full h-full"

--- a/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-features.component.tsx
+++ b/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-features.component.tsx
@@ -57,11 +57,26 @@ export function PermissionProfileFormInputFeaturesComponent({
               </FormLabel>
 
               <FormControl>
-                <GroupSelector.List messageEmpty={MESSAGES_PERMISSIONS[6.6]}>
-                  {(group, item) => (
-                    <GroupSelector.Item key={item.id} item={item} />
-                  )}
-                </GroupSelector.List>
+                <GroupSelector.Root>
+                  <GroupSelector.Search placeholder="Busque pelo grupo ou permissão..." />
+                  <GroupSelector.List<featuresInterface>
+                    messageEmpty={MESSAGES_PERMISSIONS[6.6]}
+                  >
+                    {(item) => (
+                      <GroupSelector.Item item={item} id={item.id}>
+                        {({ selected }) => (
+                          <div
+                            className="flex items-center gap-x-4 w-full h-full"
+                            key={item.id}
+                          >
+                            <GroupSelector.Checkbox.Check selected={selected} />
+                            <span>{item.name}</span>
+                          </div>
+                        )}
+                      </GroupSelector.Item>
+                    )}
+                  </GroupSelector.List>
+                </GroupSelector.Root>
               </FormControl>
 
               <FormMessage />

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-check-checkbox.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-check-checkbox.component.tsx
@@ -1,0 +1,22 @@
+import { Check, Square } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+interface GroupItemSelectorCheckCheckboxComponentProps {
+  selected: boolean
+  className?: string
+}
+
+export function GroupItemSelectorCheckCheckboxComponent({
+  selected,
+  className
+}: GroupItemSelectorCheckCheckboxComponentProps) {
+  return (
+    <>
+      {selected ? (
+        <Check className={cn('!w-3.5 !h-3.5', className)} />
+      ) : (
+        <Square className={cn('!w-3.5 !h-3.5', className)} />
+      )}
+    </>
+  )
+}

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-item.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-item.component.tsx
@@ -1,26 +1,32 @@
 import { CommandItem } from '@/modules/shared/presentation/components/shadcn/command'
-import { Check, Square } from 'lucide-react'
+import { ReactNode } from 'react'
+import type { BaseItem } from './group-item-selector-list.component'
+import { cn } from '../../lib/utils'
 import { useGroupItemSelectorContext } from '../../contexts/group-item-selector.context'
 
-export function GroupItemSelectorItem<
-  Item extends { id: number; name: string }
->({ item }: { item: Item }) {
+interface GroupItemSelectorItemProps<Item extends BaseItem> {
+  id: number
+  item: Item
+  className?: string
+  children: (props: { selected: boolean }) => ReactNode
+}
+
+export function GroupItemSelectorItem<Item extends BaseItem>({
+  id,
+  item,
+  className,
+  children
+}: GroupItemSelectorItemProps<Item>) {
   const { isSelected, toggleItem } = useGroupItemSelectorContext<Item>()
-  const selected = isSelected(item.id)
+  const selected = isSelected(id)
 
   return (
     <CommandItem
-      key={item.id}
       onSelect={() => toggleItem(item)}
-      className="flex gap-x-4 items-center justify-start"
+      className={cn('flex gap-x-4 items-center justify-start', className)}
       forceMount
     >
-      {selected ? (
-        <Check className="!w-3.5 !h-3.5" />
-      ) : (
-        <Square className="!w-3.5 !h-3.5 opacity-50" />
-      )}
-      <span>{item.name}</span>
+      {children({ selected })}
     </CommandItem>
   )
 }

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-list.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-list.component.tsx
@@ -1,8 +1,6 @@
 import {
-  Command,
   CommandEmpty,
   CommandGroup,
-  CommandInput,
   CommandList,
   CommandSeparator
 } from '@/modules/shared/presentation/components/shadcn/command'
@@ -15,64 +13,59 @@ export interface BaseItem {
 }
 
 export interface Group<Item = BaseItem> {
-  name: string
+  name?: string
   items: Item[]
 }
 
-export function GroupItemSelectorList<
-  Item extends { id: number; name: string }
->({
+interface GroupItemSelectorListProps<Item> {
+  children: (item: Item, group?: Group<Item>) => ReactNode
+  messageEmpty: string
+}
+
+export function GroupItemSelectorList<Item extends BaseItem>({
   children,
   messageEmpty
-}: {
-  children: (group: { name: string }, item: Item) => ReactNode
-  messageEmpty: string
-}) {
-  const {
-    searchValue,
-    setSearchValue,
-    searchableGroups,
-    areAllGroupItemsSelected,
-    toggleAllInGroup
-  } = useGroupItemSelectorContext<Item>()
+}: GroupItemSelectorListProps<Item>) {
+  const { searchableGroups, areAllGroupItemsSelected, toggleAllInGroup } =
+    useGroupItemSelectorContext<Item>()
+
+  if (searchableGroups.length === 0) {
+    return (
+      <CommandList>
+        <CommandEmpty>{messageEmpty}</CommandEmpty>
+      </CommandList>
+    )
+  }
 
   return (
-    <Command className="rounded-lg border shadow-md !h-auto">
-      <CommandInput
-        placeholder="Buscar permissão ou grupo..."
-        value={searchValue}
-        onValueChange={setSearchValue}
-      />
-      <CommandList>
-        {searchableGroups.length === 0 ? (
-          <CommandEmpty>{messageEmpty}</CommandEmpty>
-        ) : (
-          searchableGroups.map((group, index) => (
-            <Fragment key={group.name}>
-              <CommandGroup
-                heading={
-                  <div className="flex items-center justify-between">
-                    <span>{group.name}</span>
-                    <button
-                      type="button"
-                      onClick={() => toggleAllInGroup(group)}
-                      className="flex items-center gap-2 focus:outline-none underline underline-offset-2 text-primary-300"
-                    >
-                      {areAllGroupItemsSelected(group)
-                        ? 'Remover seleção'
-                        : 'Selecionar todos'}
-                    </button>
-                  </div>
-                }
-                forceMount
-              >
-                {group.items.map((item) => children(group, item))}
-              </CommandGroup>
-              {index !== searchableGroups.length - 1 && <CommandSeparator />}
-            </Fragment>
-          ))
-        )}
-      </CommandList>
-    </Command>
+    <CommandList>
+      {searchableGroups.map((group, index) => {
+        const allSelected = areAllGroupItemsSelected(group)
+
+        return (
+          <Fragment key={group.name}>
+            <CommandGroup
+              heading={
+                <div className="flex items-center justify-between">
+                  <span>{group.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => toggleAllInGroup(group)}
+                    className="flex items-center gap-2 focus:outline-none underline underline-offset-2 text-primary-300"
+                  >
+                    {allSelected ? 'Remover seleção' : 'Selecionar todos'}
+                  </button>
+                </div>
+              }
+              forceMount
+            >
+              {group.items.map((item) => children(item, group))}
+            </CommandGroup>
+
+            {index < searchableGroups.length - 1 && <CommandSeparator />}
+          </Fragment>
+        )
+      })}
+    </CommandList>
   )
 }

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-list.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-list.component.tsx
@@ -8,7 +8,7 @@ import { Fragment, ReactNode } from 'react'
 import { useGroupItemSelectorContext } from '../../contexts/group-item-selector.context'
 
 export interface BaseItem {
-  id: number
+  id?: number
   name: string
 }
 

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-root.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-root.component.tsx
@@ -1,0 +1,16 @@
+import type { ReactNode } from 'react'
+import { Command } from '../shadcn/command'
+
+interface GroupItemSelectorRootProps {
+  children: ReactNode
+}
+
+export function GroupItemSelectorRoot({
+  children
+}: GroupItemSelectorRootProps) {
+  return (
+    <Command className="rounded-lg border shadow-md !h-auto">
+      {children}
+    </Command>
+  )
+}

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-search.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-search.component.tsx
@@ -1,0 +1,20 @@
+import { useGroupItemSelectorContext } from '../../contexts/group-item-selector.context'
+import { CommandInput } from '../shadcn/command'
+
+interface GroupItemSelectorSearchProps {
+  placeholder: string
+}
+
+export function GroupItemSelectorSearch({
+  placeholder
+}: GroupItemSelectorSearchProps) {
+  const { searchValue, setSearchValue } = useGroupItemSelectorContext()
+
+  return (
+    <CommandInput
+      placeholder={placeholder}
+      value={searchValue}
+      onValueChange={setSearchValue}
+    />
+  )
+}

--- a/src/modules/shared/presentation/components/group-item-selector/group-item-selector-square-checkbox.component.tsx
+++ b/src/modules/shared/presentation/components/group-item-selector/group-item-selector-square-checkbox.component.tsx
@@ -1,0 +1,19 @@
+import { Square } from 'lucide-react'
+import { cn } from '../../lib/utils'
+
+interface GroupItemSelectorSquareCheckboxComponentProps {
+  selected: boolean
+}
+
+export function GroupItemSelectorSquareCheckboxComponent({
+  selected
+}: GroupItemSelectorSquareCheckboxComponentProps) {
+  return (
+    <Square
+      className={cn(
+        '!w-3.5 !h-3.5 ms-2',
+        selected && 'fill-zinc-950 dark:fill-white'
+      )}
+    />
+  )
+}

--- a/src/modules/shared/presentation/components/group-item-selector/index.ts
+++ b/src/modules/shared/presentation/components/group-item-selector/index.ts
@@ -1,11 +1,21 @@
 import { GroupItemSelectorProvider } from '../../contexts/group-item-selector.context'
 import { GroupItemSelectorToggleButton } from './group-item-selector-button-toggle.component'
+import { GroupItemSelectorCheckCheckboxComponent } from './group-item-selector-check-checkbox.component'
 import { GroupItemSelectorItem } from './group-item-selector-item.component'
 import { GroupItemSelectorList } from './group-item-selector-list.component'
+import { GroupItemSelectorRoot } from './group-item-selector-root.component'
+import { GroupItemSelectorSearch } from './group-item-selector-search.component'
+import { GroupItemSelectorSquareCheckboxComponent } from './group-item-selector-square-checkbox.component'
 
 export const GroupSelector = {
   Provider: GroupItemSelectorProvider,
   List: GroupItemSelectorList,
   Item: GroupItemSelectorItem,
-  Toggle: GroupItemSelectorToggleButton
+  Toggle: GroupItemSelectorToggleButton,
+  Root: GroupItemSelectorRoot,
+  Search: GroupItemSelectorSearch,
+  Checkbox: {
+    Square: GroupItemSelectorSquareCheckboxComponent,
+    Check: GroupItemSelectorCheckCheckboxComponent
+  }
 }

--- a/src/modules/shared/presentation/contexts/group-item-selector.context.tsx
+++ b/src/modules/shared/presentation/contexts/group-item-selector.context.tsx
@@ -5,9 +5,7 @@ import type {
   Group
 } from '../components/group-item-selector/group-item-selector-list.component'
 
-const GroupItemSelectorContext = createContext<ReturnType<
-  typeof useGroupItemSelector
-> | null>(null)
+const GroupItemSelectorContext = createContext<unknown>(null)
 
 export function GroupItemSelectorProvider<Item extends BaseItem>({
   value,
@@ -30,9 +28,7 @@ export function GroupItemSelectorProvider<Item extends BaseItem>({
 }
 
 export function useGroupItemSelectorContext<Item extends BaseItem>() {
-  const ctx = useContext(GroupItemSelectorContext) as ReturnType<
-    typeof useGroupItemSelector<Item>
-  > | null
+  const ctx = useContext(GroupItemSelectorContext)
 
   if (!ctx) {
     throw new Error(
@@ -40,5 +36,5 @@ export function useGroupItemSelectorContext<Item extends BaseItem>() {
     )
   }
 
-  return ctx
+  return ctx as ReturnType<typeof useGroupItemSelector<Item>>
 }

--- a/src/modules/shared/presentation/messages/permissions.ts
+++ b/src/modules/shared/presentation/messages/permissions.ts
@@ -10,6 +10,7 @@ type MessageKeys =
   | '6.9'
   | '6.10'
   | '6.11'
+  | '6.12'
 
 export const MESSAGES_PERMISSIONS: Record<MessageKeys, string> = {
   '6.1': 'Permissões',
@@ -22,5 +23,6 @@ export const MESSAGES_PERMISSIONS: Record<MessageKeys, string> = {
   '6.8': 'A descrição do perfil é obrigatória.',
   '6.9': 'A descrição deve ter no máximo 255 caracteres.',
   '6.10': 'Editar perfil de permissão',
-  '6.11': 'Atualize os dados para editar o perfil desejado.'
+  '6.11': 'Atualize os dados para editar o perfil desejado.',
+  '6.12': 'Selecione um perfil para vincular ao usuário'
 }

--- a/src/modules/shared/presentation/messages/users.ts
+++ b/src/modules/shared/presentation/messages/users.ts
@@ -47,10 +47,11 @@ export const MESSAGES_USERS: Record<MessageKeys, string> = {
   '5.14': 'Deseja vincular este usuário ao um contrato?',
   '5.15':
     'Avance para vincular o usuário ao contrato. Este passo é obrigatório.',
-  '5.16': 'Vinculação de contrato',
-  '5.17': 'Preencha os dados obrigatórios para vincular o contrato ao usuário.',
-  '5.18': 'Este usuário já está vinculado ao contrato.',
-  '5.19': 'Nenhum contrato encontrado.',
+  '5.16': 'Vinculação de Permissões',
+  '5.17':
+    'Preencha os dados obrigatórios para vincular os perfis de permissões ao usuário.',
+  '5.18': 'Este perfil já está vinculado ao usuário.',
+  '5.19': 'Nenhum perfil encontrado.',
   '5.20': 'Formato de arquivo inválido. Utilize um formato compatível.',
   '5.21': 'Permissões',
   '5.22': 'Atribua as permissões desejadas ao usuário selecionado.',

--- a/src/modules/users/domain/interfaces/get-user-with-permission-profile-service.interface.ts
+++ b/src/modules/users/domain/interfaces/get-user-with-permission-profile-service.interface.ts
@@ -1,0 +1,10 @@
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { UserEntity } from '../entities/user.entity'
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+
+export interface GetUserWithPermissionProfileServiceInterface {
+  execute(
+    token: TokenEntities,
+    userId: UserEntity['id']
+  ): Promise<PermissionProfileWithUserInterface[]>
+}

--- a/src/modules/users/domain/validators/http-response-user.validator.ts
+++ b/src/modules/users/domain/validators/http-response-user.validator.ts
@@ -1,13 +1,7 @@
 import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
 import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status-codes.enum'
-import type { UserInterface } from '../interfaces/user.interface'
-
 export class HttpResponseUserValidator {
-  static validate(
-    success: boolean,
-    response: UserInterface | UserInterface[] | null | undefined,
-    status: string
-  ): void {
+  static validate(success: boolean, status: string): void {
     const isValidStatus =
       status === HttpStatusCodeEnum.OK || status === HttpStatusCodeEnum.CREATE
     if (!success || !isValidStatus) {

--- a/src/modules/users/infrastructure/factories/get-user-with-permission-profile.factory.ts
+++ b/src/modules/users/infrastructure/factories/get-user-with-permission-profile.factory.ts
@@ -1,0 +1,12 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import { GetUserWithPermissionProfileService } from '../services/get-user-with-permission-profile.service'
+import type { GetUserWithPermissionProfileServiceInterface } from '../../domain/interfaces/get-user-with-permission-profile-service.interface'
+
+export class GetUserWithPermissionProfileFactory {
+  static create(): GetUserWithPermissionProfileServiceInterface {
+    const httpClient = HttpClientFactory.create(process.env.HOST_API)
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new GetUserWithPermissionProfileService(executeRequest)
+  }
+}

--- a/src/modules/users/infrastructure/services/get-user-with-permission-profile.service.ts
+++ b/src/modules/users/infrastructure/services/get-user-with-permission-profile.service.ts
@@ -1,0 +1,42 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { UserEntity } from '../../domain/entities/user.entity'
+import { HttpResponseUserValidator } from '../../domain/validators/http-response-user.validator'
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+import type { GetUserWithPermissionProfileServiceInterface } from '../../domain/interfaces/get-user-with-permission-profile-service.interface'
+
+export class GetUserWithPermissionProfileService
+  implements GetUserWithPermissionProfileServiceInterface
+{
+  constructor(private readonly executeRequest: ExecuteRequest) {}
+
+  getHttpRequestConfig(
+    token: TokenEntities,
+    userId: UserEntity['id']
+  ): HttpRequestConfig<FormData> {
+    return {
+      method: 'GET',
+      url: `/users/${userId}/perm-profiles/`,
+      headers: token.access_token && {
+        Authorization: `${token.token_type} ${token.access_token}`
+      }
+    }
+  }
+
+  async execute(
+    token: TokenEntities,
+    userId: UserEntity['id']
+  ): Promise<PermissionProfileWithUserInterface[]> {
+    const settingsAuthHTTP = this.getHttpRequestConfig(token, userId)
+    const {
+      success,
+      data,
+      status
+    }: HttpResponse<PermissionProfileWithUserInterface[]> =
+      await this.executeRequest.execute(settingsAuthHTTP)
+    HttpResponseUserValidator.validate(success, status)
+    return data
+  }
+}

--- a/src/modules/users/infrastructure/services/get-user.service.ts
+++ b/src/modules/users/infrastructure/services/get-user.service.ts
@@ -27,7 +27,7 @@ export class GetUserService implements GetUserServiceInterface {
     const settingsAuthHTTP = this.getHttpRequestConfig(token, userId)
     const { success, data, status }: HttpResponse<UserInterface> =
       await this.executeRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
     return UserFactory.create(data)
   }
 }

--- a/src/modules/users/infrastructure/services/get-users.service.ts
+++ b/src/modules/users/infrastructure/services/get-users.service.ts
@@ -30,7 +30,7 @@ export class GetUsersService implements GetUsersServiceInterface {
     const settingsAuthHTTP = this.getHttpRequestConfig(token, ids)
     const { success, data, status }: HttpResponse<UserInterface[]> =
       await this.executeRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
     return data
   }
 }

--- a/src/modules/users/infrastructure/services/post-user.service.ts
+++ b/src/modules/users/infrastructure/services/post-user.service.ts
@@ -34,8 +34,8 @@ export class PostUserService implements PostUserServiceInterface {
       user,
       operationSelectedId
     )
-    const { success, data, status }: HttpResponse<null> =
+    const { success, status }: HttpResponse<null> =
       await this.executeRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
   }
 }

--- a/src/modules/users/infrastructure/services/put-user.service.ts
+++ b/src/modules/users/infrastructure/services/put-user.service.ts
@@ -31,8 +31,8 @@ export class PutUserService implements PutUserServiceInterface {
     user: FormData
   ): Promise<void> {
     const settingsAuthHTTP = this.getHttpRequestConfig(token, userId, user)
-    const { success, data, status }: HttpResponse<UserInterface> =
+    const { success, status }: HttpResponse<UserInterface> =
       await this.httpRequest.execute(settingsAuthHTTP)
-    HttpResponseUserValidator.validate(success, data, status)
+    HttpResponseUserValidator.validate(success, status)
   }
 }

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-form-provider/bind-user-with-permission-profiles-form-provider.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-form-provider/bind-user-with-permission-profiles-form-provider.component.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useForm, FormProvider } from 'react-hook-form'
+import { useEffect, useMemo } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import type { ReactNode } from 'react'
+import {
+  BindUserWithPermissionProfileFormSchema,
+  type BindUserWithPermissionProfileFormType
+} from '../../schemas/bind-user-with-permission-profiles-form.schema'
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+
+interface BindUserWithPermissionProfileFormContextProviderComponentProps {
+  children: ReactNode
+  permissionProfiles: PermissionProfileWithUserInterface[]
+  isOpen: boolean
+}
+
+export function BindUserWithPermissionProfileFormContextProviderComponent({
+  permissionProfiles,
+  children,
+  isOpen
+}: BindUserWithPermissionProfileFormContextProviderComponentProps) {
+  const defaultValues = useMemo<BindUserWithPermissionProfileFormType>(
+    () => ({
+      perm_profile_id: permissionProfiles.map(
+        ({ perm_profile_id }) => perm_profile_id
+      )
+    }),
+    [permissionProfiles]
+  )
+
+  const methods = useForm<BindUserWithPermissionProfileFormType>({
+    resolver: zodResolver(BindUserWithPermissionProfileFormSchema),
+    defaultValues
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      methods.reset(defaultValues)
+    }
+  }, [isOpen, defaultValues, methods])
+
+  return <FormProvider {...methods}>{children}</FormProvider>
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-form-provider/index.ts
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-form-provider/index.ts
@@ -1,0 +1,5 @@
+import { BindUserWithPermissionProfileFormContextProviderComponent } from './bind-user-with-permission-profiles-form-provider.component'
+
+export const BindUserWithPermissionProfileForm = {
+  Provider: BindUserWithPermissionProfileFormContextProviderComponent
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-content.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-content.component.tsx
@@ -1,0 +1,12 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import { type ReactNode } from 'react'
+
+interface BindUserWithPermissionProfilesMenuContentComponentProps {
+  children: ReactNode
+}
+
+export function BindUserWithPermissionProfilesMenuContentComponent({
+  children
+}: BindUserWithPermissionProfilesMenuContentComponentProps) {
+  return <DrawerDialog.Content>{children}</DrawerDialog.Content>
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-footer.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-footer.component.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+interface BindUserWithPermissionProfilesMenuFooterComponentProps {
+  children: ReactNode
+}
+
+export function BindUserWithPermissionProfilesMenuFooterComponent({
+  children
+}: BindUserWithPermissionProfilesMenuFooterComponentProps) {
+  return (
+    <div className="flex flex-col-reverse sm:flex-row w-full justify-end gap-5 px-5 border-t sm:px-10 sm:py-5">
+      {children}
+    </div>
+  )
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-header.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-header.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+
+interface BindUserWithPermissionProfilesMenuHeaderComponentProps {
+  title: string
+  description: string
+}
+
+export function BindUserWithPermissionProfilesMenuHeaderComponent({
+  title,
+  description
+}: BindUserWithPermissionProfilesMenuHeaderComponentProps) {
+  return (
+    <DrawerDialog.Header>
+      <DrawerDialog.Title>{title}</DrawerDialog.Title>
+      <DrawerDialog.Description>{description}</DrawerDialog.Description>
+    </DrawerDialog.Header>
+  )
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-provider.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-provider.component.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+type BindUserWithPermissionProfilesMenuContextType = {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+
+const BindUserWithPermissionProfilesMenuContext = createContext<
+  BindUserWithPermissionProfilesMenuContextType | undefined
+>(undefined)
+
+export const BindUserWithPermissionProfilesMenuProviderComponent = ({
+  children
+}: {
+  children: ReactNode
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+  const toggle = () => setIsOpen((prev) => !prev)
+
+  return (
+    <BindUserWithPermissionProfilesMenuContext.Provider
+      value={{ isOpen, open, close, toggle }}
+    >
+      {children}
+    </BindUserWithPermissionProfilesMenuContext.Provider>
+  )
+}
+
+export const useDialog = () => {
+  const context = useContext(BindUserWithPermissionProfilesMenuContext)
+  if (!context)
+    throw new Error('useDialog must be used within a DialogProvider')
+  return context
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-root.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-root.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import type { ReactNode } from 'react'
+import { useDialog } from './bind-user-with-permission-profiles-menu-provider.component'
+
+interface BindUserWithPermissionProfilesMenuRootComponentProps {
+  children: ReactNode
+}
+
+export function BindUserWithPermissionProfilesMenuRootComponent({
+  children
+}: BindUserWithPermissionProfilesMenuRootComponentProps) {
+  const { isOpen, close } = useDialog()
+  return (
+    <DrawerDialog.Root open={isOpen} onOpenChange={close}>
+      {children}
+    </DrawerDialog.Root>
+  )
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-trigger.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-trigger.component.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { useBindUserWithPermissionProfilesMenuTrigger } from '../../hooks/use-bind-user-with-permission-profiles-menu-trigger.hook'
+
+export function BindUserWithPermissionProfilesMenuTriggerComponent() {
+  const { loadUserWithPermissionProfileBindOpenDialog } =
+    useBindUserWithPermissionProfilesMenuTrigger()
+  return (
+    <Button
+      onClick={loadUserWithPermissionProfileBindOpenDialog}
+      className="justify-start w-full h-auto cursor-pointer p-1.5 ps-3 rounded-none text-sm disabled:bg-muted-foreground [&>svg]:size-4 [&>svg]:shrink-0 shadow-none"
+    >
+      Vincular Permissões
+    </Button>
+  )
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu.component.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { UserForm } from '../user-form'
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { useDialog } from './bind-user-with-permission-profiles-menu-provider.component'
+import { BindUserWithPermissionProfilesMenu } from '.'
+import { BindUserWithPermissionProfileForm } from '../bind-user-with-permission-profiles-form-provider'
+import { useBindUserWithPermissionProfileSubmit } from '../../hooks/use-bind-user-with-permission-profile-submit.hook'
+import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+
+interface BindUserWithPermissionProfilesMenuComponentProps {
+  title: string
+  description: string
+}
+
+export function BindUserWithPermissionProfilesMenuComponent({
+  title,
+  description
+}: BindUserWithPermissionProfilesMenuComponentProps) {
+  const { isOpen, close } = useDialog()
+  const { onAction } = useBindUserWithPermissionProfileSubmit()
+
+  return (
+    <BindUserWithPermissionProfilesMenu.Root>
+      <BindUserWithPermissionProfilesMenu.Content>
+        <BindUserWithPermissionProfilesMenu.Header
+          title={title}
+          description={description}
+        />
+
+        <BindUserWithPermissionProfileForm.Provider
+          isOpen={isOpen}
+          permissionProfiles={[
+            {
+              id: 1,
+              user_id: 1,
+              perm_profile_id: 1
+            },
+            {
+              id: 2,
+              user_id: 1,
+              perm_profile_id: 2
+            },
+            {
+              id: 3,
+              user_id: 1,
+              perm_profile_id: 3
+            }
+          ]}
+        >
+          <UserForm.Form>
+            <UserForm.Input.Profiles
+              permissions={[
+                {
+                  name: 'Administrador',
+                  operation_id: 1,
+                  description:
+                    'Usuário responsável por gerenciar todos os recursos do sistema.',
+                  id: 1
+                },
+                {
+                  name: 'Coordenador',
+                  operation_id: 1,
+                  description:
+                    'Usuário responsável por supervisionar e orientar outros usuários.',
+                  id: 2
+                },
+                {
+                  name: 'Desenvolvedor',
+                  operation_id: 1,
+                  description:
+                    'Usuário especializado na manutenção e evolução do sistema.',
+                  id: 3
+                }
+              ]}
+            />
+          </UserForm.Form>
+          <BindUserWithPermissionProfilesMenu.Footer>
+            <Button
+              className="w-full sm:w-[150px]"
+              variant="outline"
+              onClick={close}
+            >
+              Cancelar
+            </Button>
+            <UserForm.Submit
+              onSubmit={(permissionProfiles: PermissionProfileEntity['id'][]) =>
+                onAction(permissionProfiles, close)
+              }
+            />
+          </BindUserWithPermissionProfilesMenu.Footer>
+        </BindUserWithPermissionProfileForm.Provider>
+      </BindUserWithPermissionProfilesMenu.Content>
+    </BindUserWithPermissionProfilesMenu.Root>
+  )
+}

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu.component.tsx
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu.component.tsx
@@ -7,6 +7,8 @@ import { BindUserWithPermissionProfilesMenu } from '.'
 import { BindUserWithPermissionProfileForm } from '../bind-user-with-permission-profiles-form-provider'
 import { useBindUserWithPermissionProfileSubmit } from '../../hooks/use-bind-user-with-permission-profile-submit.hook'
 import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+import { usePermissionProfileWithUserStore } from '../../stores/user-permission-profile.store'
+import { usePermissionProfileStore } from '@/modules/permissions/presentation/stores/permission-profile.store'
 
 interface BindUserWithPermissionProfilesMenuComponentProps {
   title: string
@@ -19,6 +21,8 @@ export function BindUserWithPermissionProfilesMenuComponent({
 }: BindUserWithPermissionProfilesMenuComponentProps) {
   const { isOpen, close } = useDialog()
   const { onAction } = useBindUserWithPermissionProfileSubmit()
+  const { userWithPermissionProfiles } = usePermissionProfileWithUserStore()
+  const { permissionProfiles } = usePermissionProfileStore()
 
   return (
     <BindUserWithPermissionProfilesMenu.Root>
@@ -30,50 +34,10 @@ export function BindUserWithPermissionProfilesMenuComponent({
 
         <BindUserWithPermissionProfileForm.Provider
           isOpen={isOpen}
-          permissionProfiles={[
-            {
-              id: 1,
-              user_id: 1,
-              perm_profile_id: 1
-            },
-            {
-              id: 2,
-              user_id: 1,
-              perm_profile_id: 2
-            },
-            {
-              id: 3,
-              user_id: 1,
-              perm_profile_id: 3
-            }
-          ]}
+          permissionProfiles={userWithPermissionProfiles}
         >
           <UserForm.Form>
-            <UserForm.Input.Profiles
-              permissions={[
-                {
-                  name: 'Administrador',
-                  operation_id: 1,
-                  description:
-                    'Usuário responsável por gerenciar todos os recursos do sistema.',
-                  id: 1
-                },
-                {
-                  name: 'Coordenador',
-                  operation_id: 1,
-                  description:
-                    'Usuário responsável por supervisionar e orientar outros usuários.',
-                  id: 2
-                },
-                {
-                  name: 'Desenvolvedor',
-                  operation_id: 1,
-                  description:
-                    'Usuário especializado na manutenção e evolução do sistema.',
-                  id: 3
-                }
-              ]}
-            />
+            <UserForm.Input.Profiles permissions={permissionProfiles} />
           </UserForm.Form>
           <BindUserWithPermissionProfilesMenu.Footer>
             <Button

--- a/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/index.ts
+++ b/src/modules/users/presentation/components/bind-user-with-permission-profiles-menu/index.ts
@@ -1,0 +1,15 @@
+import { BindUserWithPermissionProfilesMenuContentComponent } from '../bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-content.component'
+import { BindUserWithPermissionProfilesMenuFooterComponent } from '../bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-footer.component'
+import { BindUserWithPermissionProfilesMenuHeaderComponent } from '../bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-header.component'
+import { BindUserWithPermissionProfilesMenuProviderComponent } from '../bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-provider.component'
+import { BindUserWithPermissionProfilesMenuRootComponent } from './bind-user-with-permission-profiles-menu-root.component'
+import { BindUserWithPermissionProfilesMenuTriggerComponent } from './bind-user-with-permission-profiles-menu-trigger.component'
+
+export const BindUserWithPermissionProfilesMenu = {
+  Root: BindUserWithPermissionProfilesMenuRootComponent,
+  Trigger: BindUserWithPermissionProfilesMenuTriggerComponent,
+  Content: BindUserWithPermissionProfilesMenuContentComponent,
+  Footer: BindUserWithPermissionProfilesMenuFooterComponent,
+  Header: BindUserWithPermissionProfilesMenuHeaderComponent,
+  Provider: BindUserWithPermissionProfilesMenuProviderComponent
+}

--- a/src/modules/users/presentation/components/user-form/index.ts
+++ b/src/modules/users/presentation/components/user-form/index.ts
@@ -7,6 +7,7 @@ import { UserFormInputEnabledComponent } from './user-form-input-enabled.compone
 import { UserFormInputFilesComponent } from './user-form-input-files.component'
 import { UserFormInputNameComponent } from './user-form-input-name.component'
 import { UserFormInputPasswordDeadlineComponent } from './user-form-input-password-deadline.component'
+import { UserFormInputPermissionProfilesComponent } from './user-form-input-permission-profiles.component'
 import { UserFormInputPositionComponent } from './user-form-input-position.component'
 import { UserFormInputUsernameComponent } from './user-form-input-username.component'
 import { UserFormSubmitComponent } from './user-form-submit.component'
@@ -24,6 +25,7 @@ export const UserForm = {
     Files: UserFormInputFilesComponent,
     Description: UserFormInputDescriptionComponent,
     PasswordRegDeadline: UserFormInputPasswordDeadlineComponent,
+    Profiles: UserFormInputPermissionProfilesComponent,
     Enabled: UserFormInputEnabledComponent
   }
 }

--- a/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
+++ b/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
@@ -1,0 +1,97 @@
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from '@/modules/shared/presentation/components/shadcn/form'
+import { useFormContext } from 'react-hook-form'
+import { GroupSelector } from '@/modules/shared/presentation/components/group-item-selector'
+import { cn } from '@/modules/shared/presentation/lib/utils'
+import { MESSAGES_USERS } from '@/modules/shared/presentation/messages/users'
+
+interface PermissionProfilesInterface {
+  name: string
+  operation_id: number
+  description: string
+  id: number
+}
+
+interface UserFormInputPermissionProfilesComponentProps {
+  require?: boolean
+  description?: string
+  permissions: PermissionProfilesInterface[]
+}
+
+export function UserFormInputPermissionProfilesComponent({
+  permissions
+}: UserFormInputPermissionProfilesComponentProps) {
+  const { control } = useFormContext()
+
+  return (
+    <FormField
+      control={control}
+      name="perm_profile_id"
+      render={({ field }) => {
+        const { value = [], onChange } = field
+
+        return (
+          <GroupSelector.Provider
+            value={value}
+            onChange={onChange}
+            groups={[1].map(() => ({
+              name: 'Perfis de Permissão',
+              items: permissions
+            }))}
+          >
+            <FormItem>
+              <FormLabel>
+                <GroupSelector.Toggle />
+              </FormLabel>
+
+              <FormControl>
+                <GroupSelector.Root>
+                  <GroupSelector.Search placeholder="Busque pelo perfil desejado ..." />
+                  <GroupSelector.List<PermissionProfilesInterface>
+                    messageEmpty={MESSAGES_USERS[1.19]}
+                  >
+                    {(item) => (
+                      <GroupSelector.Item
+                        item={item}
+                        id={item.id}
+                        className="!p-0 hover:bg-transparent"
+                      >
+                        {({ selected }) => (
+                          <div
+                            className={cn(
+                              'flex items-center gap-x-4 !px-2 !py-1.5 w-full h-full mt-1.5',
+                              selected
+                                ? 'outline !outline-1 outline-primary-500 dark:outline-primary-300 bg-[#7aabfa0f]'
+                                : 'hover:bg-zinc-100 dark:hover:bg-zinc-900'
+                            )}
+                          >
+                            <GroupSelector.Checkbox.Check
+                              selected={selected}
+                              className="ms-2"
+                            />
+                            <ul className="flex flex-col" key={item.id}>
+                              <li>{item.name}</li>
+                              <li className="text-xs opacity-60">
+                                {item.description}
+                              </li>
+                            </ul>
+                          </div>
+                        )}
+                      </GroupSelector.Item>
+                    )}
+                  </GroupSelector.List>
+                </GroupSelector.Root>
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          </GroupSelector.Provider>
+        )
+      }}
+    />
+  )
+}

--- a/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
+++ b/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
@@ -53,12 +53,13 @@ export function UserFormInputPermissionProfilesComponent({
                 <GroupSelector.Root>
                   <GroupSelector.Search placeholder="Busque pelo perfil desejado ..." />
                   <GroupSelector.List<PermissionProfilesInterface>
-                    messageEmpty={MESSAGES_USERS[1.19]}
+                    messageEmpty={MESSAGES_USERS[5.19]}
                   >
                     {(item) => (
                       <GroupSelector.Item
                         item={item}
                         id={item.id}
+                        key={item.id}
                         className="!p-0 hover:bg-transparent"
                       >
                         {({ selected }) => (

--- a/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
+++ b/src/modules/users/presentation/components/user-form/user-form-input-permission-profiles.component.tsx
@@ -9,18 +9,12 @@ import { useFormContext } from 'react-hook-form'
 import { GroupSelector } from '@/modules/shared/presentation/components/group-item-selector'
 import { cn } from '@/modules/shared/presentation/lib/utils'
 import { MESSAGES_USERS } from '@/modules/shared/presentation/messages/users'
-
-interface PermissionProfilesInterface {
-  name: string
-  operation_id: number
-  description: string
-  id: number
-}
+import type { PermissionProfileInterface } from '@/modules/permissions/domain/interfaces/permission-profiles.interface'
 
 interface UserFormInputPermissionProfilesComponentProps {
   require?: boolean
   description?: string
-  permissions: PermissionProfilesInterface[]
+  permissions: PermissionProfileInterface[]
 }
 
 export function UserFormInputPermissionProfilesComponent({
@@ -52,7 +46,7 @@ export function UserFormInputPermissionProfilesComponent({
               <FormControl>
                 <GroupSelector.Root>
                   <GroupSelector.Search placeholder="Busque pelo perfil desejado ..." />
-                  <GroupSelector.List<PermissionProfilesInterface>
+                  <GroupSelector.List<PermissionProfileInterface>
                     messageEmpty={MESSAGES_USERS[5.19]}
                   >
                     {(item) => (

--- a/src/modules/users/presentation/hooks/use-bind-user-with-permission-profile-submit.hook.ts
+++ b/src/modules/users/presentation/hooks/use-bind-user-with-permission-profile-submit.hook.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react'
+import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+
+export function useBindUserWithPermissionProfileSubmit() {
+  const onAction = useCallback(
+    async (
+      permissionProfiles: PermissionProfileEntity['id'][],
+      onSuccess: VoidFunction
+    ): Promise<void> => {
+      try {
+        toast({
+          title: 'Perfis de permissão vinculados com sucesso!',
+          description: `Os perfis selecionados foram atribuídos ao usuário. ${JSON.stringify(permissionProfiles)}`,
+          variant: 'success'
+        })
+        onSuccess?.()
+      } catch (error) {
+        if (error instanceof HttpResponseError) {
+          toast({
+            title: 'Erro ao vincular perfis de permissão',
+            description:
+              'Não foi possível vincular os perfis ao usuário. Tente novamente ou entre em contato com o suporte.',
+            variant: 'destructive'
+          })
+        }
+      }
+    },
+    []
+  )
+
+  return { onAction }
+}

--- a/src/modules/users/presentation/hooks/use-bind-user-with-permission-profiles-menu-trigger.hook.ts
+++ b/src/modules/users/presentation/hooks/use-bind-user-with-permission-profiles-menu-trigger.hook.ts
@@ -1,12 +1,22 @@
 import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
 import { useDialog } from '../components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-provider.component'
+import { usePermissionProfileWithUserStore } from '../stores/user-permission-profile.store'
+import { useTableUser } from '../contexts/table-user.context'
+import { usePermissionProfileStore } from '@/modules/permissions/presentation/stores/permission-profile.store'
 
 export function useBindUserWithPermissionProfilesMenuTrigger() {
   const { open: openDialog } = useDialog()
+  const { id: userId } = useTableUser()
+  const { getUserWithPermissionProfiles } = usePermissionProfileWithUserStore()
+  const { getPermissionProfiles } = usePermissionProfileStore()
 
   const loadUserWithPermissionProfileBindOpenDialog = () => {
     queueMicrotask(async () => {
       try {
+        await Promise.all([
+          getUserWithPermissionProfiles(userId),
+          getPermissionProfiles()
+        ])
         openDialog()
       } catch {
         toast({

--- a/src/modules/users/presentation/hooks/use-bind-user-with-permission-profiles-menu-trigger.hook.ts
+++ b/src/modules/users/presentation/hooks/use-bind-user-with-permission-profiles-menu-trigger.hook.ts
@@ -1,0 +1,23 @@
+import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
+import { useDialog } from '../components/bind-user-with-permission-profiles-menu/bind-user-with-permission-profiles-menu-provider.component'
+
+export function useBindUserWithPermissionProfilesMenuTrigger() {
+  const { open: openDialog } = useDialog()
+
+  const loadUserWithPermissionProfileBindOpenDialog = () => {
+    queueMicrotask(async () => {
+      try {
+        openDialog()
+      } catch {
+        toast({
+          variant: 'destructive',
+          title: 'Erro ao carregar o formulário',
+          description:
+            'Não foi possível abrir o formulário no momento. Tente novamente ou entre em contato com o suporte caso o problema persista.'
+        })
+      }
+    })
+  }
+
+  return { loadUserWithPermissionProfileBindOpenDialog }
+}

--- a/src/modules/users/presentation/schemas/bind-user-with-permission-profiles-form.schema.ts
+++ b/src/modules/users/presentation/schemas/bind-user-with-permission-profiles-form.schema.ts
@@ -1,0 +1,12 @@
+import { MESSAGES_PERMISSIONS } from '@/modules/shared/presentation/messages/permissions'
+import { z } from 'zod'
+
+export const BindUserWithPermissionProfileFormSchema = z.object({
+  perm_profile_id: z.array(z.number()).min(1, {
+    message: MESSAGES_PERMISSIONS[6.12]
+  })
+})
+
+export type BindUserWithPermissionProfileFormType = z.infer<
+  typeof BindUserWithPermissionProfileFormSchema
+>

--- a/src/modules/users/presentation/stores/user-permission-profile.store.ts
+++ b/src/modules/users/presentation/stores/user-permission-profile.store.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import type { PermissionProfileWithUserInterface } from '@/modules/permissions/domain/interfaces/permission-profile-with-user.interface'
+import { GetUserWithPermissionProfileRouterApiFactory } from '@/modules/api/infrastructure/factories/get-user-with-permission-profile-router-api.factory'
+import type { UserEntity } from '../../domain/entities/user.entity'
+
+type PermissionProfileWithUserState = {
+  userWithPermissionProfiles: PermissionProfileWithUserInterface[]
+  getUserWithPermissionProfiles: (userId: UserEntity['id']) => Promise<void>
+}
+
+export const usePermissionProfileWithUserStore =
+  create<PermissionProfileWithUserState>((set) => ({
+    userWithPermissionProfiles: [],
+
+    getUserWithPermissionProfiles: async (userId: UserEntity['id']) => {
+      try {
+        const getUserWithPermissionProfileRouterApiFactory =
+          GetUserWithPermissionProfileRouterApiFactory.create()
+        const userWithPermissionProfiles =
+          await getUserWithPermissionProfileRouterApiFactory.execute(userId)
+        set({ userWithPermissionProfiles })
+      } catch (error) {
+        if (error instanceof HttpResponseError) {
+          throw error
+        }
+      }
+    }
+  }))


### PR DESCRIPTION
**Descrição:**

Implementação da listagem de perfis de permissão atribuídos a usuários. A funcionalidade contempla a criação de rotas na Router API, serviços integrados com o backend, e gerenciamento de estado com Zustand. Foram também aplicadas melhorias de consistência em interfaces e tipagens.

**Alterações:**

- **Adicionado:**

  - Rota de listagem de perfis de permissão do usuário (Router API)  
  - Interface, serviço e fábrica de listagem de perfis de permissão do usuário (Router API e Backend)  
  - Store Zustand para gerenciamento da listagem de permissões por usuário  
  - Injeção das requisições para listagem geral e por usuário  
  - Injeção das listas de perfis de permissão e perfis atribuídos ao usuário  

- **Refatorado:**

  - Interface de perfis de permissão ajustada para reutilização  
  - Definição de `id` como opcional para melhor flexibilidade em usos genéricos
