### PR TITLE
ALteração [Operações] - Removido Utilização de query parms (0/N)

### DIFF
--- a/src/modules/operations/domain/interfaces/get-operations-service.interface.ts
+++ b/src/modules/operations/domain/interfaces/get-operations-service.interface.ts
@@ -1,9 +1,6 @@
 import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
-import type { OperationInterface } from './operation.interface'
+import type { OperationEntity } from '../entities/operation.entity'
 
 export interface GetOperationsServiceInterface {
-  execute(
-    token: TokenEntities,
-    params?: number[]
-  ): Promise<OperationInterface[]>
+  execute(token: TokenEntities): Promise<OperationEntity[]>
 }

--- a/src/modules/operations/infrastructure/services/get-operations.service.ts
+++ b/src/modules/operations/infrastructure/services/get-operations.service.ts
@@ -1,34 +1,29 @@
 import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
 import type { GetOperationsServiceInterface } from '../../domain/interfaces/get-operations-service.interface'
-import type { OperationInterface } from '../../domain/interfaces/operation.interface'
 import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
 import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
 import { HttpResponseOperationValidator } from '../../domain/validators/http-response-operation.validator'
 import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { OperationEntity } from '../../domain/entities/operation.entity'
 
 export class GetOperationsService implements GetOperationsServiceInterface {
   constructor(private readonly executeRequest: ExecuteRequest) {}
 
-  getHttpRequestConfig(
-    token: TokenEntities,
-    ids?: number[]
-  ): HttpRequestConfig<null, { ids: number[] }> {
+  getHttpRequestConfig(token: TokenEntities): HttpRequestConfig {
     return {
       method: 'GET',
       url: '/operations/',
       headers: token.access_token && {
         Authorization: `${token.token_type} ${token.access_token}`
-      },
-      params: { ids }
+      }
     }
   }
 
   async execute(
     token: TokenEntities,
-    ids?: number[]
-  ): Promise<OperationInterface[]> {
-    const settingsAuthHTTP = this.getHttpRequestConfig(token, ids)
-    const { success, data, status }: HttpResponse<OperationInterface[]> =
+  ): Promise<OperationEntity[]> {
+    const settingsAuthHTTP = this.getHttpRequestConfig(token)
+    const { success, data, status }: HttpResponse<OperationEntity[]> =
       await this.executeRequest.execute(settingsAuthHTTP)
     HttpResponseOperationValidator.validate(success, data, status)
     return data

--- a/src/modules/operations/presentation/utils/get-operations.util.ts
+++ b/src/modules/operations/presentation/utils/get-operations.util.ts
@@ -1,12 +1,9 @@
 import { auth } from '@/auth'
-import { JwtTokenDecodeFactory } from '@/modules/shared/infrastructure/factories/jwt-decode.factory'
 import { GetOperationsFactory } from '../../infrastructure/factories/get-operations.factory'
 import type { OperationEntity } from '../../domain/entities/operation.entity'
 
 export async function getOperations(): Promise<OperationEntity[]> {
   const { token } = await auth()
-  const jwtDecode = JwtTokenDecodeFactory.create()
-  const { operation_ids } = jwtDecode.decode(token.access_token)
   const getOperations = GetOperationsFactory.create()
-  return await getOperations.execute(token, operation_ids)
+  return await getOperations.execute(token)
 }

--- a/src/modules/shared/infrastructure/http/middlewares/redirect-to-operations.middleware.ts
+++ b/src/modules/shared/infrastructure/http/middlewares/redirect-to-operations.middleware.ts
@@ -30,11 +30,8 @@ export async function RedirectToOperationsMiddleware(
       decodeToken(token: TokenEntities): JwtDecodeDataInterface {
         return JwtTokenDecodeFactory.create().decode(token.access_token)
       },
-      async getOperations(
-        token: TokenEntities,
-        ids: number[]
-      ): Promise<OperationInterface[]> {
-        return await GetOperationsFactory.create().execute(token, ids)
+      async getOperations(token: TokenEntities): Promise<OperationInterface[]> {
+        return await GetOperationsFactory.create().execute(token)
       },
       createOperation(data): OperationEntity {
         return OperationFactory.create(data)

--- a/src/modules/shared/presentation/utils/handle-redirect-to-operations.util.ts
+++ b/src/modules/shared/presentation/utils/handle-redirect-to-operations.util.ts
@@ -4,7 +4,7 @@ import type { OperationEntity } from '@/modules/operations/domain/entities/opera
 export interface handleRedirectToOperationsDependencies {
   getAuthToken(): Promise<TokenEntities | null>
   decodeToken(token: TokenEntities): { operation_ids: number[] }
-  getOperations(token: TokenEntities, ids: number[]): Promise<OperationEntity[]>
+  getOperations(token: TokenEntities): Promise<OperationEntity[]>
   createOperation(data: OperationEntity): OperationEntity
   saveOperationToCookies(operation: OperationEntity): void
   getRedirectUrl(single: boolean): string
@@ -23,7 +23,7 @@ export async function handleRedirectToOperationsUtil(
   const { operation_ids: operationIds } = deps.decodeToken(token)
   if (!operationIds?.length) return null
 
-  const operations = await deps.getOperations(token, operationIds)
+  const operations = await deps.getOperations(token)
   const hasSingleOperation = operationIds.length === 1
   const redirectTarget = deps.getRedirectUrl(hasSingleOperation)
 


### PR DESCRIPTION
**Descrição:**

Refatoração da lógica relacionada à recuperação de operações, com a remoção do parâmetro de `ids` tanto no serviço quanto no middleware e em pontos de injeção. A mudança visa simplificar a arquitetura, reduzir acoplamentos desnecessários e centralizar a obtenção de dados diretamente do contexto adequado.

**Alterações:**

- **Refatorado:**

  - Removido o parâmetro de `ids` do serviço de operações  
  - Removida a injeção dos `ids` das operações obtidas via JWT  
  - Middleware de redirecionamento para operações ajustado para não depender de `ids` externos
