### PR TITLE
HTTP [Redefinição de senha] - Alterado validação do status de retorno [204], mudança no envio do ID do usuário (0/N)

### DIFF
--- a/src/modules/password-reset/domain/validators/http-response-password-reset.validator.ts
+++ b/src/modules/password-reset/domain/validators/http-response-password-reset.validator.ts
@@ -3,7 +3,13 @@ import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status
 
 export class HttpResponsePasswordResetValidator {
   static validate(success: boolean, status: string): void {
-    if (!success || status !== HttpStatusCodeEnum.OK) {
+    if (
+      !success ||
+      !(
+        status === HttpStatusCodeEnum.OK ||
+        status === HttpStatusCodeEnum.NO_CONTENT
+      )
+    ) {
       throw new HttpResponseError(status)
     }
   }

--- a/src/modules/users/domain/validators/http-response-user-password-reset.validator.ts
+++ b/src/modules/users/domain/validators/http-response-user-password-reset.validator.ts
@@ -3,7 +3,9 @@ import { HttpStatusCodeEnum } from '@/modules/authentication/domain/enums/status
 
 export class HttpResponseUserPasswordResetValidator {
   static validate(success: boolean, status: string): void {
-    const isValidStatus = status === HttpStatusCodeEnum.OK
+    const isValidStatus =
+      status === HttpStatusCodeEnum.OK ||
+      status === HttpStatusCodeEnum.NO_CONTENT
     if (!success || !isValidStatus) {
       throw new HttpResponseError(status)
     }

--- a/src/modules/users/infrastructure/services/post-user-password-reset.service.ts
+++ b/src/modules/users/infrastructure/services/post-user-password-reset.service.ts
@@ -3,7 +3,7 @@ import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-
 import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
 import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
 import type { PostUserPasswordResetServiceInterface } from '../../domain/interfaces/post-user-password-reset-service.interface'
-
+import type { UserEntity } from '../../domain/entities/user.entity'
 import type { UserPasswordResetInterface } from '../../domain/interfaces/user-password-reset.interface'
 import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
 import { HttpResponseUserPasswordResetValidator } from '../../domain/validators/http-response-user-password-reset.validator'
@@ -18,12 +18,13 @@ export class PostUserPasswordResetService
 
   getHttpRequestConfig(
     token: TokenEntities,
-    userPasswordReset: FormData
+    userId: UserEntity['id'],
+    userPasswordResetFormData: FormData
   ): HttpRequestConfig<FormData> {
     return {
       method: 'POST',
-      url: `/users/password-resets`,
-      data: userPasswordReset,
+      url: `/users/${userId}/passwords`,
+      data: userPasswordResetFormData,
       headers: token.access_token && {
         Authorization: `${token.token_type} ${token.access_token}`
       }
@@ -32,17 +33,14 @@ export class PostUserPasswordResetService
 
   async execute(
     token: TokenEntities,
-    userPasswordReset: UserPasswordResetInterface
+    { days_passwd_reg_deadline, userId }: UserPasswordResetInterface
   ): Promise<void> {
-    const enrichedUserPasswordReset = {
-      user_id: userPasswordReset.userId,
-      days_passwd_reg_deadline: userPasswordReset.days_passwd_reg_deadline
-    }
     const userPasswordResetFormDataConverted = this.convertFormData.execute({
-      ...enrichedUserPasswordReset
+      days_passwd_reg_deadline
     })
     const settingsAuthHTTP = this.getHttpRequestConfig(
       token,
+      userId,
       userPasswordResetFormDataConverted
     )
     const { success, status }: HttpResponse<null> =


### PR DESCRIPTION
**Descrição:**

Refatorações no tratamento de respostas e parâmetros em rotas relacionadas a usuários, com foco em conformidade com boas práticas HTTP e simplificação da extração de dados.

**Alterações:**

- **Refatorado:**

  - Status de resposta ajustado para `204 No Content` em operações sem retorno de corpo  
  - Extração do ID do usuário diretamente pela URL, ao invés do payload da requisição  
  - Ajuste nos possíveis status de resposta para refletir os cenários esperados
