### PR TITLE
Permissão [Habilitar/Desabilitar] - Integração com backend (2/2)

### DIFF
--- a/src/app/system/operations/[operationId]/permissions/page.tsx
+++ b/src/app/system/operations/[operationId]/permissions/page.tsx
@@ -12,15 +12,6 @@ interface PermissionsPageProps {
   params: Promise<{ operationId: string }>
 }
 
-interface Data {
-  title: string
-  description: string
-  menuAddPermissionProfileTitle: string
-  menuAddPermissionProfileDescription: string
-  menuEditPermissionProfileTitle: string
-  menuEditPermissionProfileDescription: string
-}
-
 export default async function PermissionsPage({
   params
 }: PermissionsPageProps) {
@@ -31,13 +22,15 @@ export default async function PermissionsPage({
   const { operationId: rawOperationId } = await params
   const { userPermissions } = await loadAuthContext(JWT, rawOperationId)
 
-  const data: Data = {
+  const data = {
     title: MESSAGES_PERMISSIONS['6.1'],
     description: MESSAGES_PERMISSIONS['6.2'],
     menuAddPermissionProfileTitle: MESSAGES_PERMISSIONS['6.4'],
     menuAddPermissionProfileDescription: MESSAGES_PERMISSIONS['6.5'],
     menuEditPermissionProfileTitle: MESSAGES_PERMISSIONS['6.10'],
-    menuEditPermissionProfileDescription: MESSAGES_PERMISSIONS['6.11']
+    menuEditPermissionProfileDescription: MESSAGES_PERMISSIONS['6.11'],
+    menuStatusPermissionProfileTitle: MESSAGES_PERMISSIONS['6.14'],
+    menuStatusPermissionProfileDescription: MESSAGES_PERMISSIONS['6.15']
   }
 
   return (
@@ -66,6 +59,10 @@ export default async function PermissionsPage({
               permissions={userPermissions}
               editTitle={data.menuEditPermissionProfileTitle}
               editDescription={data.menuEditPermissionProfileDescription}
+              permissionProfileTitle={data.menuStatusPermissionProfileTitle}
+              permissionProfileDescription={
+                data.menuStatusPermissionProfileDescription
+              }
             />
           </TablePermissionProfiles.Item>
         </TablePermissionProfiles.Body>

--- a/src/modules/api/domain/interfaces/put-permission-profile-status-router-api-service.interface.ts
+++ b/src/modules/api/domain/interfaces/put-permission-profile-status-router-api-service.interface.ts
@@ -1,0 +1,7 @@
+import type { PermissionProfileEnableAndDisableInterface } from "@/modules/permissions/domain/interfaces/permission-profile-enable-and-disable.interface";
+
+export interface PutPermissionProfileStatusRouterApiServiceInterface {
+  execute(
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
+  ): Promise<void>
+}

--- a/src/modules/api/infrastructure/factories/put-permission-profile-status-router-api.factory.ts
+++ b/src/modules/api/infrastructure/factories/put-permission-profile-status-router-api.factory.ts
@@ -1,0 +1,17 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
+import type { PutPermissionProfileStatusRouterApiServiceInterface } from '../../domain/interfaces/put-permission-profile-status-router-api-service.interface'
+import { PutPermissionProfileStatusRouterApiService } from '../services/put-permission-profile-status-router-api.service'
+
+export class PutPermissionProfileStatusRouterApiFactory {
+  static create(): PutPermissionProfileStatusRouterApiServiceInterface {
+    const httpClient = HttpClientFactory.create('/')
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    const formDataConvert = FormDataConverterFactory.create()
+    return new PutPermissionProfileStatusRouterApiService(
+      executeRequest,
+      formDataConvert
+    )
+  }
+}

--- a/src/modules/api/infrastructure/services/put-permission-profile-status-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/put-permission-profile-status-router-api.service.ts
@@ -1,0 +1,41 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
+import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
+import type { PutPermissionProfileStatusRouterApiServiceInterface } from '../../domain/interfaces/put-permission-profile-status-router-api-service.interface'
+import { HttpResponsePermissionProfileValidator } from '@/modules/permissions/domain/validators/http-response-permission-profile.validator'
+import type { PermissionProfileEnableAndDisableInterface } from '@/modules/permissions/domain/interfaces/permission-profile-enable-and-disable.interface'
+
+export class PutPermissionProfileStatusRouterApiService
+  implements PutPermissionProfileStatusRouterApiServiceInterface
+{
+  constructor(
+    private readonly httpRequest: ExecuteRequest,
+    private readonly formData: ConvertJsonToFormData
+  ) {}
+  getHttpRequestConfig(
+    permissionProfileId: PermissionProfileEntity['id'],
+    permissionProfileEnableAndDisable: FormData
+  ): HttpRequestConfig<FormData> {
+    return {
+      method: 'PUT',
+      data: permissionProfileEnableAndDisable,
+      url: `api/permission/${permissionProfileId}/status`
+    }
+  }
+  async execute(
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
+  ): Promise<void> {
+    const userFormData = this.formData.execute({
+      ...permissionProfileEnableAndDisable
+    })
+    const settingsAuthHTTP = this.getHttpRequestConfig(
+      permissionProfileEnableAndDisable.id,
+      userFormData
+    )
+    const { success, status }: HttpResponse<null> =
+      await this.httpRequest.execute(settingsAuthHTTP)
+    HttpResponsePermissionProfileValidator.validate(success, status)
+  }
+}

--- a/src/modules/permissions/domain/interfaces/put-permission-profile-status-service.interface.ts
+++ b/src/modules/permissions/domain/interfaces/put-permission-profile-status-service.interface.ts
@@ -1,0 +1,9 @@
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { PermissionProfileEntity } from '../entities/permission-profile.entity'
+export interface PutPermissionProfileStatusServiceInterface {
+  execute(
+    token: TokenEntities,
+    permissionProfileId: PermissionProfileEntity['id'],
+    permissionProfileEnableAndDisable: FormData
+  ): Promise<void>
+}

--- a/src/modules/permissions/infrastructure/factories/put-permission-profile-status.factory.ts
+++ b/src/modules/permissions/infrastructure/factories/put-permission-profile-status.factory.ts
@@ -1,0 +1,12 @@
+import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
+import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
+import type { PutPermissionProfileStatusServiceInterface } from '../../domain/interfaces/put-permission-profile-status-service.interface'
+import { PutPermissionProfileStatusService } from '../services/put-permission-profile-status.service'
+
+export class PutPermissionProfileStatusFactory {
+  static create(): PutPermissionProfileStatusServiceInterface {
+    const httpClient = HttpClientFactory.create(process.env.HOST_API)
+    const executeRequest = ExecuteRequestFactory.create(httpClient)
+    return new PutPermissionProfileStatusService(executeRequest)
+  }
+}

--- a/src/modules/permissions/infrastructure/services/put-permission-profile-status.service.ts
+++ b/src/modules/permissions/infrastructure/services/put-permission-profile-status.service.ts
@@ -1,0 +1,47 @@
+import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
+import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
+import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
+import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
+import type { PermissionProfileEntity } from '../../domain/entities/permission-profile.entity'
+import type { PutPermissionProfileStatusServiceInterface } from '../../domain/interfaces/put-permission-profile-status-service.interface'
+import type { PermissionProfileEnableAndDisableInterface } from '../../domain/interfaces/permission-profile-enable-and-disable.interface'
+import { HttpResponsePermissionProfileValidator } from '../../domain/validators/http-response-permission-profile.validator'
+
+export class PutPermissionProfileStatusService
+  implements PutPermissionProfileStatusServiceInterface
+{
+  constructor(private readonly httpRequest: ExecuteRequest) {}
+
+  getHttpRequestConfig(
+    token: TokenEntities,
+    permissionProfileId: PermissionProfileEntity['id'],
+    permissionProfileEnableAndDisable: FormData
+  ): HttpRequestConfig<FormData> {
+    return {
+      method: 'PATCH',
+      url: `/perm_profiles/${permissionProfileId}/status`,
+      data: permissionProfileEnableAndDisable,
+      headers: token.access_token && {
+        Authorization: `${token.token_type} ${token.access_token}`
+      }
+    }
+  }
+
+  async execute(
+    token: TokenEntities,
+    permissionProfileId: PermissionProfileEntity['id'],
+    permissionProfileEnableAndDisable: FormData
+  ): Promise<void> {
+    const settingsAuthHTTP = this.getHttpRequestConfig(
+      token,
+      permissionProfileId,
+      permissionProfileEnableAndDisable
+    )
+    const {
+      success,
+      status
+    }: HttpResponse<PermissionProfileEnableAndDisableInterface> =
+      await this.httpRequest.execute(settingsAuthHTTP)
+    HttpResponsePermissionProfileValidator.validate(success, status)
+  }
+}

--- a/src/modules/permissions/presentation/components/permission-profile-form/index.ts
+++ b/src/modules/permissions/presentation/components/permission-profile-form/index.ts
@@ -5,6 +5,7 @@ import { PermissionProfileFormSubmitComponent } from './permission-profile-form-
 import { PermissionProfileFormComponent } from './permission-profile-form.component'
 import { PermissionProfileFormInputFeaturesComponent } from './permission-profile-form-input-features.component'
 import { PermissionProfileFormInputDescriptionComponent } from './permission-profile-form-input-description.component'
+import { PermissionProfileFormInputEnabledComponent } from './permission-profile-form-input-enabled.component'
 
 export const PermissionProfileForm = {
   Form: PermissionProfileFormComponent,
@@ -12,6 +13,7 @@ export const PermissionProfileForm = {
   Input: {
     Name: PermissionProfileFormInputNameComponent,
     Description: PermissionProfileFormInputDescriptionComponent,
-    Features: PermissionProfileFormInputFeaturesComponent
+    Features: PermissionProfileFormInputFeaturesComponent,
+    Enabled: PermissionProfileFormInputEnabledComponent
   }
 }

--- a/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-enabled.component.tsx
+++ b/src/modules/permissions/presentation/components/permission-profile-form/permission-profile-form-input-enabled.component.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/modules/shared/presentation/components/shadcn/form'
 import { Switch } from '@/modules/shared/presentation/components/shadcn/switch'
 import { useFormContext } from 'react-hook-form'
+import { useTablePermissionProfile } from '../../contexts/table-permission-profiles.context'
 
 interface PermissionProfileFormInputEnabledComponentProps {
   require?: boolean
@@ -19,6 +20,7 @@ export function PermissionProfileFormInputEnabledComponent({
   description
 }: PermissionProfileFormInputEnabledComponentProps) {
   const { control } = useFormContext()
+  const permissionProfile = useTablePermissionProfile()
 
   return (
     <FormField
@@ -28,24 +30,30 @@ export function PermissionProfileFormInputEnabledComponent({
         <FormItem>
           <FormLabel
             className="text-sm flex items-center gap-x-1.5 dark:text-zinc-50"
-            htmlFor="enabled-user"
+            htmlFor="enabled-permission"
           >
-            Habilitado{require ? ': *' : ':'}
             <HelpMeButtonComponent description={description} />
           </FormLabel>
 
           <FormControl>
-            <div className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
+            <div className="flex flex-row items-center justify-between rounded-lg gap-x-2 border p-3 shadow-sm">
               <div className="space-y-0.5">
-                <FormLabel>Habilitar usuário?</FormLabel>
+                <FormLabel>
+                  Permissão {field.value ? 'Habilitada' : 'Desabilitada'}
+                </FormLabel>
                 <FormDescription>
-                  Caso a opção correspondente esteja desabilitada, o usuário não
-                  poderá utilizar os recursos da aplicação.
+                  Permissão{' '}
+                  <b className="text-white/80">{permissionProfile.name}</b> será{' '}
+                  <b className="text-white/80">
+                    {' '}
+                    {!field.value ? 'Habilitada' : 'Desabilitada'}{' '}
+                  </b>{' '}
+                  caso o botão seja alterado.
                 </FormDescription>
               </div>
               <Switch
                 className="data-[state=checked]:bg-primary-600"
-                id="enabled-user"
+                id="enabled-permission"
                 checked={field.value}
                 onCheckedChange={field.onChange}
               />

--- a/src/modules/permissions/presentation/components/permission-profile-options-dropdown/permission-profile-options-dropdown-client.component.tsx
+++ b/src/modules/permissions/presentation/components/permission-profile-options-dropdown/permission-profile-options-dropdown-client.component.tsx
@@ -4,34 +4,62 @@ import { PermissionEnum } from '@/modules/system/domain/enums/permissions.enum'
 import { EditPermissionProfileMenu } from '../edit-permission-profile-menu'
 import { EditPermissionProfileMenuComponent } from '../edit-permission-profile-menu/edit-permission-profile-menu.component'
 import { PermissionProfileOptionsDropdown } from '.'
+import { PutPermissionProfileStatusMenuComponent } from '../put-permission-profile-status-menu/put-permission-profile-status-menu.component'
+import { PutPermissionProfileStatusMenu } from '../put-permission-profile-status-menu'
 
 export function PermissionProfileOptionsDropdownClientComponent({
   isAdmin,
   editTitle,
   editDescription,
+  permissionProfileTitle,
+  permissionProfileDescription,
   permissions
 }: {
   isAdmin: boolean
   editTitle: string
   editDescription: string
+  permissionProfileTitle: string
+  permissionProfileDescription: string
   permissions: Set<PermissionEnum>
 }) {
   return (
     <>
       {(isAdmin || permissions.has(PermissionEnum.PERMISSIONS_EDIT)) && (
         <EditPermissionProfileMenu.Provider>
-          <PermissionProfileOptionsDropdown.Root>
-            <PermissionProfileOptionsDropdown.Trigger />
-            <PermissionProfileOptionsDropdown.Menu>
-              <PermissionProfileOptionsDropdown.Item>
-                <EditPermissionProfileMenu.Trigger />
-              </PermissionProfileOptionsDropdown.Item>
-            </PermissionProfileOptionsDropdown.Menu>
-          </PermissionProfileOptionsDropdown.Root>
-          <EditPermissionProfileMenuComponent
-            title={editTitle}
-            description={editDescription}
-          />
+          <PutPermissionProfileStatusMenu.Provider>
+            <PermissionProfileOptionsDropdown.Root>
+              <PermissionProfileOptionsDropdown.Trigger />
+              <PermissionProfileOptionsDropdown.Menu>
+                <PermissionProfileOptionsDropdown.Item>
+                  <EditPermissionProfileMenu.Trigger />
+                </PermissionProfileOptionsDropdown.Item>
+
+                {(isAdmin ||
+                  permissions.has(
+                    PermissionEnum.PERMISSIONS_ENABLE_AND_DISABLE
+                  )) && (
+                  <PermissionProfileOptionsDropdown.Item>
+                    <PutPermissionProfileStatusMenu.Trigger />
+                  </PermissionProfileOptionsDropdown.Item>
+                )}
+              </PermissionProfileOptionsDropdown.Menu>
+            </PermissionProfileOptionsDropdown.Root>
+
+            {(isAdmin ||
+              permissions.has(
+                PermissionEnum.PERMISSIONS_ENABLE_AND_DISABLE
+              )) && (
+              <PutPermissionProfileStatusMenuComponent
+                title={permissionProfileTitle}
+                description={permissionProfileDescription}
+              />
+            )}
+
+            <EditPermissionProfileMenuComponent
+              title={editTitle}
+              description={editDescription}
+            />
+          </PutPermissionProfileStatusMenu.Provider>
         </EditPermissionProfileMenu.Provider>
       )}
     </>

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/index.ts
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/index.ts
@@ -1,0 +1,5 @@
+import { PutPermissionProfileStatusFormContextProviderComponent } from './put-permission-profile-status-form-provider.component'
+
+export const PutPermissionProfileStatusForm = {
+  Provider: PutPermissionProfileStatusFormContextProviderComponent
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/put-permission-profile-status-form-provider.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/put-permission-profile-status-form-provider.component.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import { useForm, FormProvider } from 'react-hook-form'
+import { useEffect, useMemo } from 'react'
+import { zodResolver } from '@hookform/resolvers/zod'
+import type { ReactNode } from 'react'
+import {
+  PutPermissionProfileStatusFormSchema,
+  type PutPermissionProfileStatusFormType
+} from '../../schemas/put-user-permission-profile-form.schema'
+import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+
+interface PutPermissionProfileStatusFormContextProviderComponentProps {
+  children: ReactNode
+  permissionProfile: PermissionProfileEntity
+  isOpen: boolean
+}
+
+export function PutPermissionProfileStatusFormContextProviderComponent({
+  children,
+  permissionProfile,
+  isOpen
+}: PutPermissionProfileStatusFormContextProviderComponentProps) {
+  const defaultValues = useMemo<{
+    permissionProfileId: number
+    enabled: boolean
+  }>(
+    () => ({
+      permissionProfileId: permissionProfile.id,
+      enabled: permissionProfile?.enabled
+    }),
+    [permissionProfile?.id]
+  )
+
+  const methods = useForm<PutPermissionProfileStatusFormType>({
+    resolver: zodResolver(PutPermissionProfileStatusFormSchema),
+    defaultValues
+  })
+
+  useEffect(() => {
+    if (isOpen) {
+      methods.reset(defaultValues)
+    }
+  }, [isOpen, defaultValues, methods])
+
+  return <FormProvider {...methods}>{children}</FormProvider>
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/put-permission-profile-status-form-provider.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-form-provider/put-permission-profile-status-form-provider.component.tsx
@@ -8,11 +8,11 @@ import {
   PutPermissionProfileStatusFormSchema,
   type PutPermissionProfileStatusFormType
 } from '../../schemas/put-user-permission-profile-form.schema'
-import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
+import type { PermissionProfileEnableAndDisableInterface } from '@/modules/permissions/domain/interfaces/permission-profile-enable-and-disable.interface'
 
 interface PutPermissionProfileStatusFormContextProviderComponentProps {
   children: ReactNode
-  permissionProfile: PermissionProfileEntity
+  permissionProfile: PermissionProfileEnableAndDisableInterface
   isOpen: boolean
 }
 
@@ -21,15 +21,12 @@ export function PutPermissionProfileStatusFormContextProviderComponent({
   permissionProfile,
   isOpen
 }: PutPermissionProfileStatusFormContextProviderComponentProps) {
-  const defaultValues = useMemo<{
-    permissionProfileId: number
-    enabled: boolean
-  }>(
+  const defaultValues = useMemo<PermissionProfileEnableAndDisableInterface>(
     () => ({
-      permissionProfileId: permissionProfile.id,
+      id: permissionProfile.id,
       enabled: permissionProfile?.enabled
     }),
-    [permissionProfile?.id]
+    [permissionProfile]
   )
 
   const methods = useForm<PutPermissionProfileStatusFormType>({

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/index.ts
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/index.ts
@@ -1,0 +1,15 @@
+import { PutPermissionProfileStatusMenuContentComponent } from './put-permission-profile-status-menu-content.component'
+import { PutPermissionProfileStatusMenuFooterComponent } from './put-permission-profile-status-menu-footer.component'
+import { PutPermissionProfileStatusMenuHeaderComponent } from './put-permission-profile-status-menu-header.component'
+import { PutPermissionProfileStatusMenuProviderComponent } from './put-permission-profile-status-menu-provider.component'
+import { PutPermissionProfileStatusMenuRootComponent } from './put-permission-profile-status-menu-root.component'
+import { PutPermissionProfileStatusMenuTriggerComponent } from './put-permission-profile-status-menu-trigger.component'
+
+export const PutPermissionProfileStatusMenu = {
+  Root: PutPermissionProfileStatusMenuRootComponent,
+  Trigger: PutPermissionProfileStatusMenuTriggerComponent,
+  Content: PutPermissionProfileStatusMenuContentComponent,
+  Footer: PutPermissionProfileStatusMenuFooterComponent,
+  Header: PutPermissionProfileStatusMenuHeaderComponent,
+  Provider: PutPermissionProfileStatusMenuProviderComponent
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-content.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-content.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import { type ReactNode } from 'react'
+
+interface PutPermissionProfileStatusMenuContentComponentProps {
+  children: ReactNode
+  className?: string
+}
+
+export function PutPermissionProfileStatusMenuContentComponent({
+  children,
+  className
+}: PutPermissionProfileStatusMenuContentComponentProps) {
+  return (
+    <DrawerDialog.Content className={className}>
+      {children}
+    </DrawerDialog.Content>
+  )
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-footer.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-footer.component.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+interface PutPermissionProfileStatusMenuFooterComponentProps {
+  children: ReactNode
+}
+
+export function PutPermissionProfileStatusMenuFooterComponent({
+  children
+}: PutPermissionProfileStatusMenuFooterComponentProps) {
+  return (
+    <div className="flex flex-col-reverse sm:flex-row w-full justify-end gap-5 px-5 border-t sm:px-10 sm:py-5">
+      {children}
+    </div>
+  )
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-header.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-header.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+
+interface PutPermissionProfileStatusMenuHeaderComponentProps {
+  title: string
+  description: string
+}
+
+export function PutPermissionProfileStatusMenuHeaderComponent({
+  title,
+  description
+}: PutPermissionProfileStatusMenuHeaderComponentProps) {
+  return (
+    <DrawerDialog.Header>
+      <DrawerDialog.Title>{title}</DrawerDialog.Title>
+      <DrawerDialog.Description>{description}</DrawerDialog.Description>
+    </DrawerDialog.Header>
+  )
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-provider.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-provider.component.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { createContext, useContext, useState, ReactNode } from 'react'
+
+type PutPermissionProfileStatusMenuContextType = {
+  isOpen: boolean
+  open: () => void
+  close: () => void
+  toggle: () => void
+}
+
+const PutPermissionProfileStatusMenuContext = createContext<
+  PutPermissionProfileStatusMenuContextType | undefined
+>(undefined)
+
+export const PutPermissionProfileStatusMenuProviderComponent = ({
+  children
+}: {
+  children: ReactNode
+}) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+  const toggle = () => setIsOpen((prev) => !prev)
+
+  return (
+    <PutPermissionProfileStatusMenuContext.Provider
+      value={{ isOpen, open, close, toggle }}
+    >
+      {children}
+    </PutPermissionProfileStatusMenuContext.Provider>
+  )
+}
+
+export const useDialog = () => {
+  const context = useContext(PutPermissionProfileStatusMenuContext)
+  if (!context)
+    throw new Error('useDialog must be used within a DialogProvider')
+  return context
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-root.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-root.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import type { ReactNode } from 'react'
+import { useDialog } from './put-permission-profile-status-menu-provider.component'
+
+interface PutPermissionProfileStatusMenuRootComponentProps {
+  children: ReactNode
+}
+
+export function PutPermissionProfileStatusMenuRootComponent({
+  children
+}: PutPermissionProfileStatusMenuRootComponentProps) {
+  const { isOpen, close } = useDialog()
+  return (
+    <DrawerDialog.Root open={isOpen} onOpenChange={close}>
+      {children}
+    </DrawerDialog.Root>
+  )
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-trigger.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu-trigger.component.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { usePutPermissionProfileStatusMenuTrigger } from '../../hooks/use-put-permission-profile-status-menu-trigger.hook'
+
+export function PutPermissionProfileStatusMenuTriggerComponent() {
+  const { loadUserStatusOpenDialog } = usePutPermissionProfileStatusMenuTrigger()
+  return (
+    <Button
+      className="justify-start w-full h-auto cursor-pointer p-1.5 ps-3 rounded-none text-sm disabled:bg-muted-foreground [&>svg]:size-4 [&>svg]:shrink-0 shadow-none"
+      onClick={loadUserStatusOpenDialog}
+    >
+     Habilitar/Desabilitar
+    </Button>
+  )
+}

--- a/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu.component.tsx
+++ b/src/modules/permissions/presentation/components/put-permission-profile-status-menu/put-permission-profile-status-menu.component.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { PutPermissionProfileStatusMenu } from '.'
+import { usePutPermissionProfileStatusSubmit } from '../../hooks/use-update-permission-profile-status-submit.hook'
+import { useDialog } from './put-permission-profile-status-menu-provider.component'
+import { useTablePermissionProfile } from '../../contexts/table-permission-profiles.context'
+import { PutPermissionProfileStatusForm } from '../put-permission-profile-status-form-provider'
+import { PermissionProfileForm } from '../permission-profile-form'
+
+interface PutPermissionProfileStatusMenuComponentProps {
+  title: string
+  description: string
+}
+
+export function PutPermissionProfileStatusMenuComponent({
+  title,
+  description
+}: PutPermissionProfileStatusMenuComponentProps) {
+  const { isOpen, close } = useDialog()
+  const { onAction } = usePutPermissionProfileStatusSubmit()
+  const permissionProfile = useTablePermissionProfile()
+
+  return (
+    <PutPermissionProfileStatusMenu.Root>
+      <PutPermissionProfileStatusMenu.Content className="lg:!w-[600px] lg:!h-auto">
+        <PutPermissionProfileStatusMenu.Header
+          title={title}
+          description={description}
+        />
+
+        <PutPermissionProfileStatusForm.Provider
+          permissionProfile={permissionProfile}
+          isOpen={isOpen}
+        >
+          <PermissionProfileForm.Form>
+            <PermissionProfileForm.Input.Enabled />
+          </PermissionProfileForm.Form>
+
+          <PutPermissionProfileStatusMenu.Footer>
+            <Button
+              className="w-full sm:w-[150px]"
+              variant="outline"
+              onClick={close}
+            >
+              Cancelar
+            </Button>
+            <PermissionProfileForm.Submit
+              onSubmit={(permissionProfileStatus: {
+                enabled: boolean
+                permissionProfileId: number
+              }) => onAction(permissionProfileStatus, close)}
+            />
+          </PutPermissionProfileStatusMenu.Footer>
+        </PutPermissionProfileStatusForm.Provider>
+      </PutPermissionProfileStatusMenu.Content>
+    </PutPermissionProfileStatusMenu.Root>
+  )
+}

--- a/src/modules/permissions/presentation/components/table-permission-profiles/table-permission-profiles-item.component.tsx
+++ b/src/modules/permissions/presentation/components/table-permission-profiles/table-permission-profiles-item.component.tsx
@@ -36,6 +36,12 @@ export function TablePermissionProfilesItemComponent({
       <TableCell
         className={cn(baseCell, truncateText, 'flex items-center gap-x-3.5')}
       >
+        {!permission.enabled ? (
+          <span className="block bg-red-500 outline-2 outline outline-red-600 h-1 w-1 rounded-full"></span>
+        ) : (
+          <span className="block bg-green-500 outline-2 outline outline-green-600 h-1 w-1 rounded-full"></span>
+        )}
+
         {permission.name}
       </TableCell>
       <TableCell className="pe-5 sm:pe-10 text-right" colSpan={1}>

--- a/src/modules/permissions/presentation/contexts/table-permission-profiles.context.tsx
+++ b/src/modules/permissions/presentation/contexts/table-permission-profiles.context.tsx
@@ -2,9 +2,12 @@
 
 import { createContext, useContext } from 'react'
 import type { PermissionProfileInterface } from '../../domain/interfaces/permission-profiles.interface'
+import type { PermissionProfileEnableAndDisableInterface } from '../../domain/interfaces/permission-profile-enable-and-disable.interface'
 
-export const TablePermissionProfilesContext =
-  createContext<PermissionProfileInterface | null>(null)
+export const TablePermissionProfilesContext = createContext<
+  | (PermissionProfileInterface & PermissionProfileEnableAndDisableInterface)
+  | null
+>(null)
 
 export const useTablePermissionProfile = () => {
   const context = useContext(TablePermissionProfilesContext)

--- a/src/modules/permissions/presentation/hooks/use-put-permission-profile-status-menu-trigger.hook.ts
+++ b/src/modules/permissions/presentation/hooks/use-put-permission-profile-status-menu-trigger.hook.ts
@@ -1,0 +1,23 @@
+import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
+import { useDialog } from '../components/put-permission-profile-status-menu/put-permission-profile-status-menu-provider.component'
+
+export function usePutPermissionProfileStatusMenuTrigger() {
+  const { open: openDialog } = useDialog()
+
+  const loadUserStatusOpenDialog = () => {
+    queueMicrotask(async () => {
+      try {
+        openDialog()
+      } catch {
+        toast({
+          variant: 'destructive',
+          title: 'Erro ao carregar o formulário',
+          description:
+            'Não foi possível abrir o formulário no momento. Tente novamente ou entre em contato com o suporte caso o problema persista.'
+        })
+      }
+    })
+  }
+
+  return { loadUserStatusOpenDialog }
+}

--- a/src/modules/permissions/presentation/hooks/use-update-permission-profile-status-submit.hook.ts
+++ b/src/modules/permissions/presentation/hooks/use-update-permission-profile-status-submit.hook.ts
@@ -1,0 +1,38 @@
+import { useCallback } from 'react'
+import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
+import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
+import { usePermissionProfileStore } from '../stores/permission-profile.store'
+
+export function usePutPermissionProfileStatusSubmit() {
+  const { getPermissionProfiles } = usePermissionProfileStore()
+  const onAction = useCallback(
+    async (
+      permissionProfileStatus: {
+        enabled: boolean
+        permissionProfileId: number
+      },
+      onSuccess: VoidFunction
+    ): Promise<void> => {
+      try {
+        await getPermissionProfiles()
+        toast({
+          title: 'Status da permissão alterada com sucesso!',
+          variant: 'success'
+        })
+        onSuccess?.()
+      } catch (error) {
+        if (error instanceof HttpResponseError) {
+          toast({
+            title: 'Erro ao alterar o status da permissão',
+            description:
+              'Ocorreu um problema ao tentar alterar o status. Verifique e tente novamente',
+            variant: 'destructive'
+          })
+        }
+      }
+    },
+    [getPermissionProfiles]
+  )
+
+  return { onAction }
+}

--- a/src/modules/permissions/presentation/hooks/use-update-permission-profile-status-submit.hook.ts
+++ b/src/modules/permissions/presentation/hooks/use-update-permission-profile-status-submit.hook.ts
@@ -2,21 +2,21 @@ import { useCallback } from 'react'
 import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
 import { HttpResponseError } from '@/modules/shared/infrastructure/errors/http-response.error'
 import { usePermissionProfileStore } from '../stores/permission-profile.store'
+import type { PermissionProfileEnableAndDisableInterface } from '../../domain/interfaces/permission-profile-enable-and-disable.interface'
 
 export function usePutPermissionProfileStatusSubmit() {
-  const { getPermissionProfiles } = usePermissionProfileStore()
+  const { getPermissionProfiles, updatePermissionProfileStatus } =
+    usePermissionProfileStore()
   const onAction = useCallback(
     async (
-      permissionProfileStatus: {
-        enabled: boolean
-        permissionProfileId: number
-      },
+      permissionProfileStatus: PermissionProfileEnableAndDisableInterface,
       onSuccess: VoidFunction
     ): Promise<void> => {
       try {
+        await updatePermissionProfileStatus(permissionProfileStatus)
         await getPermissionProfiles()
         toast({
-          title: 'Status da permissão alterada com sucesso!',
+          title: 'Status da permissão foi alterada com sucesso!',
           variant: 'success'
         })
         onSuccess?.()
@@ -31,7 +31,7 @@ export function usePutPermissionProfileStatusSubmit() {
         }
       }
     },
-    [getPermissionProfiles]
+    [getPermissionProfiles, updatePermissionProfileStatus]
   )
 
   return { onAction }

--- a/src/modules/permissions/presentation/schemas/put-user-permission-profile-form.schema.ts
+++ b/src/modules/permissions/presentation/schemas/put-user-permission-profile-form.schema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const PutPermissionProfileStatusFormSchema = z.object({
+  permissionProfileId: z.number(),
+  enabled: z.boolean().nullable()
+})
+
+export type PutPermissionProfileStatusFormType = z.infer<
+  typeof PutPermissionProfileStatusFormSchema
+>

--- a/src/modules/permissions/presentation/schemas/put-user-permission-profile-form.schema.ts
+++ b/src/modules/permissions/presentation/schemas/put-user-permission-profile-form.schema.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 export const PutPermissionProfileStatusFormSchema = z.object({
-  permissionProfileId: z.number(),
+  id: z.number(),
   enabled: z.boolean().nullable()
 })
 

--- a/src/modules/permissions/presentation/stores/permission-profile.store.ts
+++ b/src/modules/permissions/presentation/stores/permission-profile.store.ts
@@ -11,6 +11,8 @@ import type { FeaturesInterface } from '../../domain/interfaces/features.interfa
 import { DeleteFeatureRouterApiFactory } from '@/modules/api/infrastructure/factories/delete-feature-router-api.factory'
 import type { PermissionProfileAndFeaturesInterface } from '../../domain/interfaces/permission-profile-and-features'
 import { PostPermissionProfileAndFeaturesRouterApiFactory } from '@/modules/api/infrastructure/factories/post-permission-profile-and-features-router-api.factory'
+import type { PermissionProfileEnableAndDisableInterface } from '../../domain/interfaces/permission-profile-enable-and-disable.interface'
+import { PutPermissionProfileStatusRouterApiFactory } from '@/modules/api/infrastructure/factories/put-permission-profile-status-router-api.factory'
 
 type UserState = {
   permissionProfiles: PermissionProfileInterface[]
@@ -39,6 +41,10 @@ type UserState = {
   deleteFeature: (
     featureId: FeaturesInterface['id'],
     permissionProfileId: PermissionProfileInterface['id']
+  ) => Promise<void>
+
+  updatePermissionProfileStatus: (
+    updatePermissionProfileStatus: PermissionProfileEnableAndDisableInterface
   ) => Promise<void>
 }
 
@@ -135,6 +141,22 @@ export const usePermissionProfileStore = create<UserState>((set) => ({
       await deleteFeatureRouterApiFactory.execute(
         featureId,
         permissionProfileId
+      )
+    } catch (error) {
+      if (error instanceof HttpResponseError) {
+        throw error
+      }
+    }
+  },
+
+  updatePermissionProfileStatus: async (
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
+  ) => {
+    try {
+      const putPermissionProfileStatusRouterApiFactory =
+        PutPermissionProfileStatusRouterApiFactory.create()
+      await putPermissionProfileStatusRouterApiFactory.execute(
+        permissionProfileEnableAndDisable
       )
     } catch (error) {
       if (error instanceof HttpResponseError) {

--- a/src/modules/shared/presentation/messages/permissions.ts
+++ b/src/modules/shared/presentation/messages/permissions.ts
@@ -12,6 +12,8 @@ type MessageKeys =
   | '6.11'
   | '6.12'
   | '6.13'
+  | '6.14'
+  | '6.15'
 
 export const MESSAGES_PERMISSIONS: Record<MessageKeys, string> = {
   '6.1': 'Permissões',
@@ -27,5 +29,8 @@ export const MESSAGES_PERMISSIONS: Record<MessageKeys, string> = {
   '6.11': 'Atualize os dados para editar o perfil desejado.',
   '6.12': 'Selecione um perfil para vincular ao usuário',
   '6.13':
-    'O perfil de permissão selecionado será aplicado apenas aos contratos escolhidos. Caso nenhum contrato seja selecionado, as permissões serão aplicadas globalmente a todos os contratos.'
+    'O perfil de permissão selecionado será aplicado apenas aos contratos escolhidos. Caso nenhum contrato seja selecionado, as permissões serão aplicadas globalmente a todos os contratos.',
+  '6.14': 'Habilitar/Desabilitar',
+  '6.15':
+    'Caso a opção correspondente esteja desabilitada, a permissão não estará mais disponível na lista para usuários comuns.'
 }


### PR DESCRIPTION
**Descrição:**

Implementação completa da funcionalidade de habilitar/desabilitar permissões, contemplando camadas de serviço para Router API e Backend, integração com store e formulário, além de hooks para submissão.

**Alterações:**

- **Adicionado:**

  - Interface de implementação do serviço de habilitar/desabilitar (Router API)  
  - Fábrica de construção do serviço de habilitar/desabilitar (Router API)  
  - Serviço de habilitar/desabilitar (Router API)  
  - Interface de implementação do serviço de habilitar/desabilitar (Backend)  
  - Fábrica de construção do serviço de habilitar/desabilitar (Backend)  
  - Serviço de habilitar/desabilitar (Backend)  
  - Função para atualizar o status "habilitar/desabilitar" na store  
  - Hook de submit para o formulário de habilitar/desabilitar permissões
