### PR TITLE
HTTP [Perfis de Permissões] - Alterado formato do corpo da requisição

### DIFF
--- a/src/app/api/permission/[permissionProfileId]/status/route.ts
+++ b/src/app/api/permission/[permissionProfileId]/status/route.ts
@@ -13,7 +13,7 @@ export async function PUT(
   }: { params: Promise<{ permissionProfileId: PermissionProfileEntity['id'] }> }
 ): Promise<NextResponse> {
   try {
-    const permissionProfileEnableAndDisable = await req.formData()
+    const permissionProfileEnableAndDisable = await req.json()
     const { token } = await auth()
     const { permissionProfileId } = await params
     const putPermissionProfileStatusFactory =

--- a/src/modules/api/infrastructure/factories/put-permission-profile-status-router-api.factory.ts
+++ b/src/modules/api/infrastructure/factories/put-permission-profile-status-router-api.factory.ts
@@ -1,6 +1,5 @@
 import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
 import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
-import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
 import type { PutPermissionProfileStatusRouterApiServiceInterface } from '../../domain/interfaces/put-permission-profile-status-router-api-service.interface'
 import { PutPermissionProfileStatusRouterApiService } from '../services/put-permission-profile-status-router-api.service'
 
@@ -8,10 +7,6 @@ export class PutPermissionProfileStatusRouterApiFactory {
   static create(): PutPermissionProfileStatusRouterApiServiceInterface {
     const httpClient = HttpClientFactory.create('/')
     const executeRequest = ExecuteRequestFactory.create(httpClient)
-    const formDataConvert = FormDataConverterFactory.create()
-    return new PutPermissionProfileStatusRouterApiService(
-      executeRequest,
-      formDataConvert
-    )
+    return new PutPermissionProfileStatusRouterApiService(executeRequest)
   }
 }

--- a/src/modules/api/infrastructure/services/put-permission-profile-status-router-api.service.ts
+++ b/src/modules/api/infrastructure/services/put-permission-profile-status-router-api.service.ts
@@ -1,8 +1,6 @@
 import type { ExecuteRequest } from '@/modules/shared/infrastructure/services/execute-request.service'
 import type { HttpRequestConfig } from '@/modules/shared/domain/interfaces/http-request-config.interface'
 import type { HttpResponse } from '@/modules/shared/domain/interfaces/http-response.interface'
-import type { PermissionProfileEntity } from '@/modules/permissions/domain/entities/permission-profile.entity'
-import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
 import type { PutPermissionProfileStatusRouterApiServiceInterface } from '../../domain/interfaces/put-permission-profile-status-router-api-service.interface'
 import { HttpResponsePermissionProfileValidator } from '@/modules/permissions/domain/validators/http-response-permission-profile.validator'
 import type { PermissionProfileEnableAndDisableInterface } from '@/modules/permissions/domain/interfaces/permission-profile-enable-and-disable.interface'
@@ -10,29 +8,21 @@ import type { PermissionProfileEnableAndDisableInterface } from '@/modules/permi
 export class PutPermissionProfileStatusRouterApiService
   implements PutPermissionProfileStatusRouterApiServiceInterface
 {
-  constructor(
-    private readonly httpRequest: ExecuteRequest,
-    private readonly formData: ConvertJsonToFormData
-  ) {}
+  constructor(private readonly httpRequest: ExecuteRequest) {}
   getHttpRequestConfig(
-    permissionProfileId: PermissionProfileEntity['id'],
-    permissionProfileEnableAndDisable: FormData
-  ): HttpRequestConfig<FormData> {
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
+  ): HttpRequestConfig<PermissionProfileEnableAndDisableInterface> {
     return {
       method: 'PUT',
       data: permissionProfileEnableAndDisable,
-      url: `api/permission/${permissionProfileId}/status`
+      url: `api/permission/${permissionProfileEnableAndDisable.id}/status`
     }
   }
   async execute(
     permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
   ): Promise<void> {
-    const userFormData = this.formData.execute({
-      ...permissionProfileEnableAndDisable
-    })
     const settingsAuthHTTP = this.getHttpRequestConfig(
-      permissionProfileEnableAndDisable.id,
-      userFormData
+      permissionProfileEnableAndDisable
     )
     const { success, status }: HttpResponse<null> =
       await this.httpRequest.execute(settingsAuthHTTP)

--- a/src/modules/permissions/domain/interfaces/permission-profile-and-features.ts
+++ b/src/modules/permissions/domain/interfaces/permission-profile-and-features.ts
@@ -2,5 +2,5 @@ export interface PermissionProfileAndFeaturesInterface {
   operation_id: number
   perm_profile_name: string
   perm_profile_description: string
-  feature_ids: number[]
+  feature_id: number[]
 }

--- a/src/modules/permissions/domain/interfaces/put-permission-profile-status-service.interface.ts
+++ b/src/modules/permissions/domain/interfaces/put-permission-profile-status-service.interface.ts
@@ -1,9 +1,10 @@
 import type { TokenEntities } from '@/modules/authentication/domain/entities/token.entity'
 import type { PermissionProfileEntity } from '../entities/permission-profile.entity'
+import type { PermissionProfileEnableAndDisableInterface } from './permission-profile-enable-and-disable.interface'
 export interface PutPermissionProfileStatusServiceInterface {
   execute(
     token: TokenEntities,
     permissionProfileId: PermissionProfileEntity['id'],
-    permissionProfileEnableAndDisable: FormData
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
   ): Promise<void>
 }

--- a/src/modules/permissions/infrastructure/factories/post-permission-profile-and-features.factory.ts
+++ b/src/modules/permissions/infrastructure/factories/post-permission-profile-and-features.factory.ts
@@ -1,6 +1,5 @@
 import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/http-client.factory'
 import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
-import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
 import { PostPermissionProfileAndFeaturesService } from '../services/post-permission-profile-and-features.service'
 import type { PostPermissionProfileAndFeaturesServiceInterface } from '../../domain/interfaces/post-permission-profile-and-features-service.interface'
 
@@ -8,10 +7,6 @@ export class PostPermissionProfileAndFeaturesFactory {
   static create(): PostPermissionProfileAndFeaturesServiceInterface {
     const httpClient = HttpClientFactory.create(process.env.HOST_API)
     const executeRequest = ExecuteRequestFactory.create(httpClient)
-    const formDataConvert = FormDataConverterFactory.create()
-    return new PostPermissionProfileAndFeaturesService(
-      executeRequest,
-      formDataConvert
-    )
+    return new PostPermissionProfileAndFeaturesService(executeRequest)
   }
 }

--- a/src/modules/permissions/infrastructure/factories/post-permission-profile.factory.ts
+++ b/src/modules/permissions/infrastructure/factories/post-permission-profile.factory.ts
@@ -2,13 +2,11 @@ import { HttpClientFactory } from '@/modules/shared/infrastructure/factories/htt
 import { ExecuteRequestFactory } from '@/modules/shared/infrastructure/factories/request.factory'
 import type { PostPermissionProfileServiceInterface } from '../../domain/interfaces/post-permission-profile-service.interface'
 import { PostPermissionProfileService } from '../services/post-permission-profile.service'
-import { FormDataConverterFactory } from '@/modules/shared/infrastructure/factories/form-data-converter.factory'
 
 export class PostPermissionProfileFactory {
   static create(): PostPermissionProfileServiceInterface {
     const httpClient = HttpClientFactory.create(process.env.HOST_API)
     const executeRequest = ExecuteRequestFactory.create(httpClient)
-    const formDataConvert = FormDataConverterFactory.create()
-    return new PostPermissionProfileService(executeRequest, formDataConvert)
+    return new PostPermissionProfileService(executeRequest)
   }
 }

--- a/src/modules/permissions/infrastructure/services/delete-feature.service.ts
+++ b/src/modules/permissions/infrastructure/services/delete-feature.service.ts
@@ -14,7 +14,7 @@ export class DeleteFeatureService implements DeleteFeatureServiceInterface {
     token: TokenEntities,
     featureId: FeaturesInterface['id'],
     permissionProfileId: PermissionProfileInterface['id']
-  ): HttpRequestConfig<FormData> {
+  ): HttpRequestConfig {
     return {
       method: 'DELETE',
       url: `/perm-profiles/${permissionProfileId}/features/${featureId}`,

--- a/src/modules/permissions/infrastructure/services/post-feature.service.ts
+++ b/src/modules/permissions/infrastructure/services/post-feature.service.ts
@@ -5,19 +5,20 @@ import type { TokenEntities } from '@/modules/authentication/domain/entities/tok
 import type { PermissionProfileInterface } from '../../domain/interfaces/permission-profiles.interface'
 import type { PostFeatureServiceInterface } from '../../domain/interfaces/post-feature-service.interface'
 import { HttpResponsePermissionProfileValidator } from '../../domain/validators/http-response-permission-profile.validator'
+import type { FeaturesInterface } from '../../domain/interfaces/features.interface'
 
 export class PostFeatureService implements PostFeatureServiceInterface {
   constructor(private readonly httpRequest: ExecuteRequest) {}
 
   getHttpRequestConfig(
     token: TokenEntities,
-    featureFormData: FormData,
-    permissionProfileId: number
-  ): HttpRequestConfig<FormData> {
+    features: FeaturesInterface['id'][],
+    permissionProfileId: PermissionProfileInterface['id']
+  ): HttpRequestConfig<FeaturesInterface['id'][]> {
     return {
       method: 'POST',
       url: `/perm-profiles/${permissionProfileId}/features`,
-      data: featureFormData,
+      data: features,
       headers: token.access_token && {
         Authorization: `${token.token_type} ${token.access_token}`
       }
@@ -26,18 +27,12 @@ export class PostFeatureService implements PostFeatureServiceInterface {
 
   async execute(
     token: TokenEntities,
-    features: number[],
+    features: FeaturesInterface['id'][],
     permissionProfileId: PermissionProfileInterface['id']
   ): Promise<void> {
-    const formData = new FormData()
-
-    features.forEach((featureId) => {
-      formData.append('feature_id', String(featureId))
-    })
-
     const settingsAuthHTTP = this.getHttpRequestConfig(
       token,
-      formData,
+      features,
       permissionProfileId
     )
 

--- a/src/modules/permissions/infrastructure/services/post-permission-profile-and-features.service.ts
+++ b/src/modules/permissions/infrastructure/services/post-permission-profile-and-features.service.ts
@@ -5,25 +5,21 @@ import type { TokenEntities } from '@/modules/authentication/domain/entities/tok
 import type { PermissionProfileInterface } from '../../domain/interfaces/permission-profiles.interface'
 import type { PostPermissionProfileAndFeaturesServiceInterface } from '../../domain/interfaces/post-permission-profile-and-features-service.interface'
 import { HttpResponsePermissionProfileValidator } from '../../domain/validators/http-response-permission-profile.validator'
-import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
 import type { PermissionProfileAndFeaturesInterface } from '../../domain/interfaces/permission-profile-and-features'
 
 export class PostPermissionProfileAndFeaturesService
   implements PostPermissionProfileAndFeaturesServiceInterface
 {
-  constructor(
-    private readonly httpRequest: ExecuteRequest,
-    private readonly formData: ConvertJsonToFormData
-  ) {}
+  constructor(private readonly httpRequest: ExecuteRequest) {}
 
   getHttpRequestConfig(
     token: TokenEntities,
-    permissionProfileAndFeaturesFormData: FormData
-  ): HttpRequestConfig<FormData> {
+    permissionProfileAndFeatures: PermissionProfileAndFeaturesInterface
+  ): HttpRequestConfig<PermissionProfileAndFeaturesInterface> {
     return {
       method: 'POST',
       url: `/perm-profiles/all-in-one`,
-      data: permissionProfileAndFeaturesFormData,
+      data: permissionProfileAndFeatures,
       headers: token.access_token && {
         Authorization: `${token.token_type} ${token.access_token}`
       }
@@ -34,25 +30,9 @@ export class PostPermissionProfileAndFeaturesService
     token: TokenEntities,
     permissionProfileAndFeatures: PermissionProfileAndFeaturesInterface
   ): Promise<void> {
-    const permissionProfileAndFeaturesFormDataConverted = this.formData.execute(
-      {
-        operation_id: permissionProfileAndFeatures.operation_id,
-        perm_profile_name: permissionProfileAndFeatures.perm_profile_name,
-        perm_profile_description:
-          permissionProfileAndFeatures.perm_profile_description
-      }
-    )
-
-    permissionProfileAndFeatures.feature_ids.forEach((featureId) => {
-      permissionProfileAndFeaturesFormDataConverted.append(
-        'feature_id',
-        String(featureId)
-      )
-    })
-
     const settingsAuthHTTP = this.getHttpRequestConfig(
       token,
-      permissionProfileAndFeaturesFormDataConverted
+      permissionProfileAndFeatures
     )
 
     const { success, status }: HttpResponse<PermissionProfileInterface> =

--- a/src/modules/permissions/infrastructure/services/post-permission-profile.service.ts
+++ b/src/modules/permissions/infrastructure/services/post-permission-profile.service.ts
@@ -6,24 +6,20 @@ import type { PermissionProfileInterface } from '../../domain/interfaces/permiss
 import type { PostPermissionProfileServiceInterface } from '../../domain/interfaces/post-permission-profile-service.interface'
 import { HttpResponsePermissionProfileValidator } from '../../domain/validators/http-response-permission-profile.validator'
 import { PermissionProfileEntity } from '../../domain/entities/permission-profile.entity'
-import type { ConvertJsonToFormData } from '@/modules/shared/infrastructure/services/convert-json-to-form-data.service'
 
 export class PostPermissionProfileService
   implements PostPermissionProfileServiceInterface
 {
-  constructor(
-    private readonly httpRequest: ExecuteRequest,
-    private readonly formData: ConvertJsonToFormData
-  ) {}
+  constructor(private readonly httpRequest: ExecuteRequest) {}
 
   getHttpRequestConfig(
     token: TokenEntities,
-    permissionProfileFormData: FormData
-  ): HttpRequestConfig<FormData> {
+    permissionProfile: PermissionProfileEntity
+  ): HttpRequestConfig<PermissionProfileEntity> {
     return {
       method: 'POST',
       url: `/perm-profiles`,
-      data: permissionProfileFormData,
+      data: permissionProfile,
       headers: token.access_token && {
         Authorization: `${token.token_type} ${token.access_token}`
       }
@@ -39,12 +35,9 @@ export class PostPermissionProfileService
       permissionProfile.description,
       permissionProfile.operation_id
     )
-    const permissionProfileFormDataConverted = this.formData.execute({
-      ...enrichedPermissionProfile
-    })
     const settingsAuthHTTP = this.getHttpRequestConfig(
       token,
-      permissionProfileFormDataConverted
+      enrichedPermissionProfile
     )
     const { success, data, status }: HttpResponse<PermissionProfileInterface> =
       await this.httpRequest.execute(settingsAuthHTTP)

--- a/src/modules/permissions/infrastructure/services/put-permission-profile-status.service.ts
+++ b/src/modules/permissions/infrastructure/services/put-permission-profile-status.service.ts
@@ -15,8 +15,8 @@ export class PutPermissionProfileStatusService
   getHttpRequestConfig(
     token: TokenEntities,
     permissionProfileId: PermissionProfileEntity['id'],
-    permissionProfileEnableAndDisable: FormData
-  ): HttpRequestConfig<FormData> {
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
+  ): HttpRequestConfig<PermissionProfileEnableAndDisableInterface> {
     return {
       method: 'PATCH',
       url: `/perm-profiles/${permissionProfileId}/status`,
@@ -30,7 +30,7 @@ export class PutPermissionProfileStatusService
   async execute(
     token: TokenEntities,
     permissionProfileId: PermissionProfileEntity['id'],
-    permissionProfileEnableAndDisable: FormData
+    permissionProfileEnableAndDisable: PermissionProfileEnableAndDisableInterface
   ): Promise<void> {
     const settingsAuthHTTP = this.getHttpRequestConfig(
       token,

--- a/src/modules/permissions/presentation/hooks/use-add-permission-profile-submit.hook.ts
+++ b/src/modules/permissions/presentation/hooks/use-add-permission-profile-submit.hook.ts
@@ -27,7 +27,7 @@ export function useAddPermissionProfileSubmit() {
           operation_id: Number(operationId),
           perm_profile_name: permissionProfileForm.name,
           perm_profile_description: permissionProfileForm.description,
-          feature_ids: permissionProfileForm.features
+          feature_id: permissionProfileForm.features
         })
         await getPermissionProfiles()
         toast({


### PR DESCRIPTION
**Descrição:**

Implementação de reconstrução do formato de envio paras requisições de perfis de permissão, anteriormente enviado no formato formData agora será no formato JSON

**Alterações:**

- **Refatorado:**

  - Requisições alteradas para envio no formato **JSON**, garantindo maior consistência e compatibilidade entre os serviços