### PR TITLE
Menu [Pontos] - Seção de ver mais

### DIFF
--- a/src/app/system/operations/[operationId]/operation-options/contracts/[contractId]/configurations/points/page.tsx
+++ b/src/app/system/operations/[operationId]/operation-options/contracts/[contractId]/configurations/points/page.tsx
@@ -25,6 +25,8 @@ interface Data {
   menuPatchPointStatusDescription: string
   menuPostPointLaneTitle: string
   menuPostPointLaneDescription: string
+  menuViewMorePointTitle: string
+  menuViewMorePointDescription: string
 }
 
 export default async function PointsPage({ params }: PointsPageProps) {
@@ -47,7 +49,9 @@ export default async function PointsPage({ params }: PointsPageProps) {
     menuPatchPointStatusTitle: MESSAGES_POINT['14.9'],
     menuPatchPointStatusDescription: MESSAGES_POINT['14.10'],
     menuPostPointLaneTitle: MESSAGES_POINT['14.11'],
-    menuPostPointLaneDescription: MESSAGES_POINT['14.12']
+    menuPostPointLaneDescription: MESSAGES_POINT['14.12'],
+    menuViewMorePointTitle: MESSAGES_POINT['14.15'],
+    menuViewMorePointDescription: MESSAGES_POINT[14.16]
   }
 
   return (
@@ -80,6 +84,8 @@ export default async function PointsPage({ params }: PointsPageProps) {
               patchStatusDescription={data.menuPatchPointStatusDescription}
               postPointLaneTitle={data.menuPostPointLaneTitle}
               postPointLaneDescription={data.menuPostPointLaneDescription}
+              viewMorePointLaneTitle={data.menuViewMorePointTitle}
+              ViewMorePointLaneDescription={data.menuViewMorePointDescription}
               permissions={userPermissions}
             />
           </TablePoints.Item>

--- a/src/modules/points/presentation/components/point-options-dropdown/point-options-dropdown-client.component.tsx
+++ b/src/modules/points/presentation/components/point-options-dropdown/point-options-dropdown-client.component.tsx
@@ -8,6 +8,8 @@ import { PatchPointStatusMenu } from '../patch-point-status-menu'
 import { PatchPointStatusMenuComponent } from '../patch-point-status-menu/patch-point-status-menu.component'
 import { PostPointLaneMenu } from '../post-point-lane-menu'
 import { PostPointLaneMenuComponent } from '../post-point-lane-menu/post-point-lane-menu.component'
+import { ViewMorePointMenu } from '../view-more-point-menu'
+import { ViewMorePointMenuComponent } from '../view-more-point-menu/view-more-point-menu.component'
 
 export function PointOptionsDropdownClient({
   isAdmin,
@@ -17,7 +19,9 @@ export function PointOptionsDropdownClient({
   patchStatusTitle,
   patchStatusDescription,
   postPointLaneTitle,
-  postPointLaneDescription
+  postPointLaneDescription,
+  viewMorePointLaneTitle,
+  ViewMorePointLaneDescription
 }: {
   isAdmin: boolean
   patchTitle: string
@@ -26,60 +30,73 @@ export function PointOptionsDropdownClient({
   patchStatusDescription: string
   postPointLaneTitle: string
   postPointLaneDescription: string
+  viewMorePointLaneTitle: string
+  ViewMorePointLaneDescription: string
   permissions: Set<PermissionEnum>
 }) {
   return (
-    <PostPointLaneMenu.Provider>
-      <PatchPointMenu.Provider>
-        <PatchPointStatusMenu.Provider>
-          <PointOptionsDropdown.Root>
-            <PointOptionsDropdown.Trigger />
+    <ViewMorePointMenu.Provider>
+      <PostPointLaneMenu.Provider>
+        <PatchPointMenu.Provider>
+          <PatchPointStatusMenu.Provider>
+            <PointOptionsDropdown.Root>
+              <PointOptionsDropdown.Trigger />
 
-            <PointOptionsDropdown.Menu>
-              {isAdmin && (
+              <PointOptionsDropdown.Menu>
+                <PointOptionsDropdown.Item>
+                  <ViewMorePointMenu.Trigger />
+                </PointOptionsDropdown.Item>
+
                 <PointOptionsDropdown.Item>
                   <PostPointLaneMenu.Trigger />
                 </PointOptionsDropdown.Item>
-              )}
 
-              {(isAdmin || permissions.has(PermissionEnum.POINTS_EDIT)) && (
-                <PointOptionsDropdown.Item>
-                  <PatchPointMenu.Trigger />
-                </PointOptionsDropdown.Item>
-              )}
+                {(isAdmin || permissions.has(PermissionEnum.POINTS_EDIT)) && (
+                  <PointOptionsDropdown.Item>
+                    <PatchPointMenu.Trigger />
+                  </PointOptionsDropdown.Item>
+                )}
 
-              {(isAdmin ||
-                permissions.has(PermissionEnum.POINTS_ENABLE_AND_DISABLE)) && (
-                <PointOptionsDropdown.Item>
-                  <PatchPointStatusMenu.Trigger />
-                </PointOptionsDropdown.Item>
-              )}
-            </PointOptionsDropdown.Menu>
-          </PointOptionsDropdown.Root>
+                {(isAdmin ||
+                  permissions.has(
+                    PermissionEnum.POINTS_ENABLE_AND_DISABLE
+                  )) && (
+                  <PointOptionsDropdown.Item>
+                    <PatchPointStatusMenu.Trigger />
+                  </PointOptionsDropdown.Item>
+                )}
+              </PointOptionsDropdown.Menu>
+            </PointOptionsDropdown.Root>
 
-          {isAdmin && (
+            {
+              <ViewMorePointMenuComponent
+                title={viewMorePointLaneTitle}
+                description={ViewMorePointLaneDescription}
+              />
+            }
+
             <PostPointLaneMenuComponent
               title={postPointLaneTitle}
               description={postPointLaneDescription}
             />
-          )}
 
-          {(isAdmin ||
-            permissions.has(PermissionEnum.POINTS_ENABLE_AND_DISABLE)) && (
-            <PatchPointStatusMenuComponent
-              title={patchStatusTitle}
-              description={patchStatusDescription}
-            />
-          )}
+            {(isAdmin ||
+              permissions.has(PermissionEnum.POINTS_ENABLE_AND_DISABLE)) && (
+              <PatchPointStatusMenuComponent
+                title={patchStatusTitle}
+                description={patchStatusDescription}
+              />
+            )}
 
-          {(isAdmin || permissions.has(PermissionEnum.POINTS_EDIT)) && (
-            <PatchPointMenuComponent
-              title={patchTitle}
-              description={patchDescription}
-            />
-          )}
-        </PatchPointStatusMenu.Provider>
-      </PatchPointMenu.Provider>
-    </PostPointLaneMenu.Provider>
+            {(isAdmin || permissions.has(PermissionEnum.POINTS_EDIT)) && (
+              <PatchPointMenuComponent
+                title={patchTitle}
+                description={patchDescription}
+              />
+            )}
+          </PatchPointStatusMenu.Provider>
+        </PatchPointMenu.Provider>
+      </PostPointLaneMenu.Provider>
+    </ViewMorePointMenu.Provider>
   )
 }

--- a/src/modules/points/presentation/components/view-more-point-menu/index.ts
+++ b/src/modules/points/presentation/components/view-more-point-menu/index.ts
@@ -1,0 +1,19 @@
+import { ViewMorePointMenuProvider } from '../../contexts/view-more-point-menu.context'
+import { ViewMorePointGroupComponent } from './view-more-point-group.component'
+import { ViewMorePointItemComponent } from './view-more-point-item.component'
+import { ViewMorePointMenuContentComponent } from './view-more-point-menu-content.component'
+import { ViewMorePointMenuFooterComponent } from './view-more-point-menu-footer.component'
+import { ViewMorePointMenuHeaderComponent } from './view-more-point-menu-header.component'
+import { ViewMorePointMenuRootComponent } from './view-more-point-menu-root.component'
+import { ViewMorePointMenuTriggerComponent } from './view-more-point-menu-trigger.component'
+
+export const ViewMorePointMenu = {
+  Root: ViewMorePointMenuRootComponent,
+  Trigger: ViewMorePointMenuTriggerComponent,
+  Content: ViewMorePointMenuContentComponent,
+  Footer: ViewMorePointMenuFooterComponent,
+  Header: ViewMorePointMenuHeaderComponent,
+  Provider: ViewMorePointMenuProvider,
+  Group: ViewMorePointGroupComponent,
+  Item: ViewMorePointItemComponent
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-group.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-group.component.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+
+interface ViewMorePointGroupComponentProps {
+  children: ReactNode
+  cols?: number
+}
+
+export function ViewMorePointGroupComponent({
+  children,
+  cols = 2
+}: ViewMorePointGroupComponentProps) {
+  const colClass = cols === 1 ? 'grid-cols-1' : 'grid-cols-2'
+  return <div className={`grid ${colClass} gap-7`}>{children}</div>
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-item.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-item.component.tsx
@@ -11,7 +11,11 @@ export function ViewMorePointItemComponent({
   title,
   notFoundData
 }: ViewMorePointItemComponentProps) {
-  const hasContent = Boolean(children)
+  const hasContent =
+    children !== undefined &&
+    children !== null &&
+    !(typeof children === 'string' && children.trim() === '')
+
   return (
     <div className="flex flex-col gap-y-1.5 min-h-12">
       <strong className="text-sm font-medium opacity-80">{title}:</strong>

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-item.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-item.component.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react'
+
+interface ViewMorePointItemComponentProps {
+  children: ReactNode
+  title: string
+  notFoundData: string
+}
+
+export function ViewMorePointItemComponent({
+  children,
+  title,
+  notFoundData
+}: ViewMorePointItemComponentProps) {
+  const hasContent = Boolean(children)
+  return (
+    <div className="flex flex-col gap-y-1.5 min-h-12">
+      <strong className="text-sm font-medium opacity-80">{title}:</strong>
+      {hasContent ? (
+        <div className="font-normal">{children}</div>
+      ) : (
+        <div className="font-normal opacity-70">{notFoundData}</div>
+      )}
+    </div>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-content.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-content.component.tsx
@@ -1,0 +1,12 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import { type ReactNode } from 'react'
+
+interface ViewMorePointMenuContentComponentProps {
+  children: ReactNode
+}
+
+export function ViewMorePointMenuContentComponent({
+  children
+}: ViewMorePointMenuContentComponentProps) {
+  return <DrawerDialog.Content>{children}</DrawerDialog.Content>
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-footer.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-footer.component.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from 'react'
+
+interface ViewMorePointMenuFooterComponentProps {
+  children: ReactNode
+}
+
+export function ViewMorePointMenuFooterComponent({
+  children
+}: ViewMorePointMenuFooterComponentProps) {
+  return (
+    <div className="flex flex-col-reverse sm:flex-row w-full justify-end gap-5 px-5 border-t sm:px-10 sm:py-5">
+      {children}
+    </div>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-header.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-header.component.tsx
@@ -1,0 +1,18 @@
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+
+interface ViewMorePointMenuHeaderComponentProps {
+  title: string
+  description: string
+}
+
+export function ViewMorePointMenuHeaderComponent({
+  title,
+  description
+}: ViewMorePointMenuHeaderComponentProps) {
+  return (
+    <DrawerDialog.Header>
+      <DrawerDialog.Title>{title}</DrawerDialog.Title>
+      <DrawerDialog.Description>{description}</DrawerDialog.Description>
+    </DrawerDialog.Header>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-root.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-root.component.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { DrawerDialog } from '@/modules/shared/presentation/components/dialog-with-drawer'
+import { type ReactNode } from 'react'
+
+interface ViewMorePointMenuRootComponentProps {
+  children: ReactNode
+  isOpen: boolean
+  close: () => void
+}
+
+export function ViewMorePointMenuRootComponent({
+  children,
+  isOpen,
+  close
+}: ViewMorePointMenuRootComponentProps) {
+  return (
+    <DrawerDialog.Root open={isOpen} onOpenChange={close}>
+      {children}
+    </DrawerDialog.Root>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-trigger.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu-trigger.component.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { useViewMorePointMenuTrigger } from '../../hooks/use-view-more-point-menu-trigger.hook'
+
+export function ViewMorePointMenuTriggerComponent() {
+  const { loadViewMorePointOpenDialog } = useViewMorePointMenuTrigger()
+  return (
+    <Button
+      className="justify-start w-full h-auto cursor-pointer p-1.5 ps-3 rounded-none text-sm disabled:bg-muted-foreground [&>svg]:size-4 [&>svg]:shrink-0 shadow-none"
+      onClick={loadViewMorePointOpenDialog}
+    >
+      Ver Mais
+    </Button>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu.component.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { Button } from '@/modules/shared/presentation/components/shadcn/button'
+import { ViewMorePointMenu } from '.'
+import { useTablePoint } from '../../contexts/table-point.context'
+import { useViewMorePointMenuContext } from '../../contexts/view-more-point-menu.context'
+import { useLaneStore } from '@/modules/lanes/presentation/stores/lanes.store'
+import { useMemo } from 'react'
+import type { LaneEntity } from '@/modules/lanes/domain/entities/lane.entity'
+
+interface ViewMorePointMenuComponentProps {
+  title: string
+  description: string
+}
+
+export function ViewMorePointMenuComponent({
+  title,
+  description
+}: ViewMorePointMenuComponentProps) {
+  const { contractLanes } = useLaneStore()
+  const { isOpen, close } = useViewMorePointMenuContext()
+  const { point } = useTablePoint()
+
+  const isLanesSelected = useMemo<LaneEntity[]>(
+    () =>
+      contractLanes
+        .filter((contractLane) => contractLane.point_id == point.id)
+        .map((contractLane) => contractLane.lane),
+    [contractLanes, point.id]
+  )
+
+  return (
+    <ViewMorePointMenu.Root isOpen={isOpen} close={close}>
+      <ViewMorePointMenu.Content>
+        <ViewMorePointMenu.Header title={title} description={description} />
+
+        <main className="flex flex-col flex-1 h-full w-full gap-y-8 overflow-auto p-8">
+          <ViewMorePointMenu.Group>
+            <ViewMorePointMenu.Item title="Nome" notFoundData="Sem Informação">
+              {point.name}
+            </ViewMorePointMenu.Item>
+            <ViewMorePointMenu.Item
+              title="Habilitado"
+              notFoundData="Sem Informação"
+            >
+              {point.enabled ? 'Sim' : 'Não'}
+            </ViewMorePointMenu.Item>
+          </ViewMorePointMenu.Group>
+          <ViewMorePointMenu.Group cols={1}>
+            <ViewMorePointMenu.Item
+              title="Descrição"
+              notFoundData="Sem Informação"
+            >
+              {point.description}
+            </ViewMorePointMenu.Item>
+          </ViewMorePointMenu.Group>
+          <ViewMorePointMenu.Group cols={1}>
+            <ViewMorePointMenu.Item
+              title="Configuração"
+              notFoundData="Sem Informação"
+            >
+              {JSON.stringify(point.cfg, null, 2)}
+            </ViewMorePointMenu.Item>
+          </ViewMorePointMenu.Group>
+          <ViewMorePointMenu.Group cols={1}>
+            <ViewMorePointMenu.Item
+              title="Faixas Selecionadas"
+              notFoundData="Sem Informação"
+            >
+              <div className="flex flex-wrap gap-1">
+                {isLanesSelected.map((lane: LaneEntity) => (
+                  <div
+                    key={lane.id}
+                    className="flex items-center justify-between w-fit gap-4 rounded-md border border-input py-2 px-4"
+                  >
+                    <div className="flex flex-col gap-0.5 overflow-hidden">
+                      <h4 className="text-xs truncate font-medium">
+                        {lane.name}
+                      </h4>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </ViewMorePointMenu.Item>
+          </ViewMorePointMenu.Group>
+        </main>
+
+        <ViewMorePointMenu.Footer>
+          <Button
+            className="w-full sm:w-[150px]"
+            variant="outline"
+            onClick={close}
+          >
+            Fechar
+          </Button>
+        </ViewMorePointMenu.Footer>
+      </ViewMorePointMenu.Content>
+    </ViewMorePointMenu.Root>
+  )
+}

--- a/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu.component.tsx
+++ b/src/modules/points/presentation/components/view-more-point-menu/view-more-point-menu.component.tsx
@@ -65,22 +65,24 @@ export function ViewMorePointMenuComponent({
           <ViewMorePointMenu.Group cols={1}>
             <ViewMorePointMenu.Item
               title="Faixas Selecionadas"
-              notFoundData="Sem Informação"
+              notFoundData="Nenhuma faixa selecionada"
             >
-              <div className="flex flex-wrap gap-1">
-                {isLanesSelected.map((lane: LaneEntity) => (
-                  <div
-                    key={lane.id}
-                    className="flex items-center justify-between w-fit gap-4 rounded-md border border-input py-2 px-4"
-                  >
-                    <div className="flex flex-col gap-0.5 overflow-hidden">
-                      <h4 className="text-xs truncate font-medium">
-                        {lane.name}
-                      </h4>
+              {isLanesSelected.length > 0 ? (
+                <div className="flex flex-wrap gap-1">
+                  {isLanesSelected.map((lane: LaneEntity) => (
+                    <div
+                      key={lane.id}
+                      className="flex items-center justify-between w-fit gap-4 rounded-md border border-input py-2 px-4"
+                    >
+                      <div className="flex flex-col gap-0.5 overflow-hidden">
+                        <h4 className="text-xs truncate font-medium">
+                          {lane.name}
+                        </h4>
+                      </div>
                     </div>
-                  </div>
-                ))}
-              </div>
+                  ))}
+                </div>
+              ) : null}
             </ViewMorePointMenu.Item>
           </ViewMorePointMenu.Group>
         </main>

--- a/src/modules/points/presentation/contexts/view-more-point-menu.context.tsx
+++ b/src/modules/points/presentation/contexts/view-more-point-menu.context.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import { createContext, useContext, ReactNode } from 'react'
+import {
+  useViewMorePointMenu,
+  type UseViewMorePointMenuReturn
+} from '../hooks/use-view-more-point-menu.hook'
+
+const ViewMorePointMenuContext = createContext<
+  UseViewMorePointMenuReturn | undefined
+>(undefined)
+
+export const ViewMorePointMenuProvider = ({
+  children
+}: {
+  children: ReactNode
+}) => {
+  const value = useViewMorePointMenu()
+  return (
+    <ViewMorePointMenuContext.Provider value={value}>
+      {children}
+    </ViewMorePointMenuContext.Provider>
+  )
+}
+
+export const useViewMorePointMenuContext = () => {
+  const context = useContext(ViewMorePointMenuContext)
+  if (!context) {
+    throw new Error(
+      'useViewMorePointMenuContext must be used within a ViewMorePointMenuProvider'
+    )
+  }
+  return context
+}

--- a/src/modules/points/presentation/hooks/use-post-point-lane-submit.hook.ts
+++ b/src/modules/points/presentation/hooks/use-post-point-lane-submit.hook.ts
@@ -22,23 +22,33 @@ export function usePostPointLaneSubmit() {
       onSuccess?: VoidFunction
     ) => {
       try {
-        const formLanesSelected = formLaneIds || []
-
         const apiLanesSelected = contractLanes
-          .filter((item) => item.point_id !== null)
+          .filter((item) => item.point_id === point.id)
           .map((item) => item.lane.id)
 
-        const toAdd = formLanesSelected.filter(
+        const toAdd = formLaneIds.filter(
           (id) => !apiLanesSelected.includes(id)
         )
-        const toDelete = apiLanesSelected.filter(
-          (id) => !formLanesSelected.includes(id)
+        let toDelete = apiLanesSelected.filter(
+          (id) => !formLaneIds.includes(id)
         )
 
         for (const laneId of toAdd) {
           await postPointLane(
             { operationId, contractId, pointId: String(point.id) },
             laneId
+          )
+        }
+
+        if (toAdd.length > 0) {
+          await getPoints({ contractId, operationId })
+
+          const freshApiLanesSelected = contractLanes
+            .filter((item) => item.point_id === point.id)
+            .map((item) => item.lane.id)
+
+          toDelete = freshApiLanesSelected.filter(
+            (id) => !formLaneIds.includes(id)
           )
         }
 

--- a/src/modules/points/presentation/hooks/use-view-more-point-menu-trigger.hook.ts
+++ b/src/modules/points/presentation/hooks/use-view-more-point-menu-trigger.hook.ts
@@ -1,0 +1,29 @@
+import { toast } from '@/modules/shared/presentation/components/hooks/use-toast'
+import { useViewMorePointMenuContext } from '../contexts/view-more-point-menu.context'
+import { useLaneStore } from '@/modules/lanes/presentation/stores/lanes.store'
+import type { UrlParams } from '@/modules/shared/domain/interfaces/url-params.interface'
+import { useParams } from 'next/navigation'
+
+export function useViewMorePointMenuTrigger() {
+  const { open: openDialog } = useViewMorePointMenuContext()
+  const { getContractLanes } = useLaneStore()
+  const { operationId, contractId }: UrlParams = useParams()
+
+  const loadViewMorePointOpenDialog = () => {
+    queueMicrotask(async () => {
+      try {
+        await getContractLanes({ operationId, contractId })
+        openDialog()
+      } catch {
+        toast({
+          variant: 'destructive',
+          title: 'Erro ao carregar o formulário',
+          description:
+            'Não foi possível abrir o formulário no momento. Tente novamente ou entre em contato com o suporte caso o problema persista.'
+        })
+      }
+    })
+  }
+
+  return { loadViewMorePointOpenDialog }
+}

--- a/src/modules/points/presentation/hooks/use-view-more-point-menu.hook.ts
+++ b/src/modules/points/presentation/hooks/use-view-more-point-menu.hook.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import { useState } from 'react'
+
+export const useViewMorePointMenu = () => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = () => setIsOpen(true)
+  const close = () => setIsOpen(false)
+  const toggle = () => setIsOpen((prev) => !prev)
+
+  return { isOpen, open, close, toggle }
+}
+
+export type UseViewMorePointMenuReturn = ReturnType<typeof useViewMorePointMenu>

--- a/src/modules/shared/presentation/messages/points.ts
+++ b/src/modules/shared/presentation/messages/points.ts
@@ -13,6 +13,8 @@ type MessageKeys =
   | '14.12'
   | '14.13'
   | '14.14'
+  | '14.15'
+  | '14.16'
 
 export const MESSAGES_POINT: Record<MessageKeys, string> = {
   '14.1': 'Pontos',
@@ -29,5 +31,7 @@ export const MESSAGES_POINT: Record<MessageKeys, string> = {
   '14.11': 'Vincular Faixas',
   '14.12': 'Selecione as faixas desejadas para o vinculo do ponto.',
   '14.13': 'O nome deve ter no máximo 150 caracteres.',
-  '14.14': 'A descrição deve ter no máximo 150 caracteres.'
+  '14.14': 'A descrição deve ter no máximo 150 caracteres.',
+  '14.15': 'Informações do Ponto',
+  '14.16': 'Veja mais informações sobre o ponto selecionado'
 }


### PR DESCRIPTION
**Descrição:**

Implementação completa da funcionalidade **"Ver mais sobre o ponto"**, incluindo componente visual, contexto, hooks, mensagens e integração ao menu suspenso.  
Foram adicionados controles de estado, mensagens e ajustes de vínculo e feedback visual.

**Alterações:**

- **Adicionado:**

  - Componente de **ver mais sobre o ponto**
  - Opção de **"ver mais"** no menu suspenso
  - Mensagens do menu de ver mais (componentes e ponto)
  - Contexto dedicado para o menu de ver mais
  - Hook de gatilho para abertura/fechamento do menu de ver mais
  - Hook principal de controle do menu de ver mais

- **Corrigido:**

  - Ajuste de vínculo de pontos
  - Mensagem exibida quando nenhuma faixa está selecionada
