### PR TITLE
Correção [Descrições] - Campos de descrição retornando null caso de campo limpo

### DIFF
--- a/src/modules/permissions/domain/entities/permission-profile.entity.ts
+++ b/src/modules/permissions/domain/entities/permission-profile.entity.ts
@@ -3,7 +3,7 @@ import type { PermissionProfileInterface } from '../interfaces/permission-profil
 export class PermissionProfileEntity implements PermissionProfileInterface {
   constructor(
     public name: string,
-    public description: string,
+    public description?: string | null,
     public id?: number
   ) {}
 }

--- a/src/modules/permissions/domain/interfaces/permission-profiles.interface.ts
+++ b/src/modules/permissions/domain/interfaces/permission-profiles.interface.ts
@@ -1,5 +1,5 @@
 export interface PermissionProfileInterface {
   id?: number
   name: string
-  description: string
+  description?: string | null
 }

--- a/src/modules/permissions/presentation/components/add-permission-profile-menu/add-permission-profile-menu.component.tsx
+++ b/src/modules/permissions/presentation/components/add-permission-profile-menu/add-permission-profile-menu.component.tsx
@@ -34,7 +34,7 @@ export function AddPermissionProfileMenuComponent({
         <AddPermissionProfileForm.Provider isOpen={isOpen}>
           <PermissionProfileForm.Form>
             <PermissionProfileForm.Input.Name require />
-            <PermissionProfileForm.Input.Description require />
+            <PermissionProfileForm.Input.Description />
             <PermissionProfileForm.Input.Features
               require
               permissions={features}

--- a/src/modules/permissions/presentation/schemas/add-permission-profile-form.schema.ts
+++ b/src/modules/permissions/presentation/schemas/add-permission-profile-form.schema.ts
@@ -7,12 +7,12 @@ export const AddPermissionProfilesFormSchema = z.object({
   }),
   description: z
     .string()
-    .nonempty({
-      message: MESSAGES_PERMISSIONS[6.8]
-    })
     .max(255, {
       message: MESSAGES_PERMISSIONS[6.9]
-    }),
+    })
+    .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val)),
   features: z.array(z.number()).optional()
 })
 

--- a/src/modules/permissions/presentation/schemas/edit-permission-profile-form.schema.ts
+++ b/src/modules/permissions/presentation/schemas/edit-permission-profile-form.schema.ts
@@ -7,12 +7,12 @@ export const EditPermissionProfilesFormSchema = z.object({
   }),
   description: z
     .string()
-    .nonempty({
-      message: MESSAGES_PERMISSIONS[6.8]
-    })
     .max(255, {
       message: MESSAGES_PERMISSIONS[6.9]
-    }),
+    })
+    .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val)),
   features: z.array(z.number()).optional()
 })
 

--- a/src/modules/points/domain/entities/point.entity.ts
+++ b/src/modules/points/domain/entities/point.entity.ts
@@ -3,7 +3,7 @@ import type { PointInterface } from '../interfaces/point.interface'
 export class PointEntity implements PointInterface {
   constructor(
     public name: string,
-    public description?: string,
+    public description?: string | null,
     public cfg?: string,
     public id?: number,
     public enabled?: boolean

--- a/src/modules/points/domain/interfaces/point.interface.ts
+++ b/src/modules/points/domain/interfaces/point.interface.ts
@@ -1,7 +1,7 @@
 export interface PointInterface {
   id?: number
   name: string
-  description?: string
+  description?: string | null
   cfg?: string
   enabled?: boolean
 }

--- a/src/modules/points/presentation/components/point-form/point-form-submit.component.tsx
+++ b/src/modules/points/presentation/components/point-form/point-form-submit.component.tsx
@@ -12,14 +12,14 @@ export function PointFormSubmitComponent<T>({
   onSubmit
 }: PointFormSubmitComponentProps<T>) {
   const { handleSubmit, formState } = useFormContext<T>()
-  const { isSubmitting, isSubmitSuccessful } = formState
+  const { isSubmitting } = formState
 
   return (
     <Button
       type="submit"
       className="w-full sm:w-[150px]"
       variant="primary"
-      disabled={isSubmitting || isSubmitSuccessful}
+      disabled={isSubmitting}
       onClick={handleSubmit(onSubmit)}
     >
       Confirmar <LoadingSpinComponent loading={isSubmitting} />

--- a/src/modules/points/presentation/schemas/patch-point-form.schema.ts
+++ b/src/modules/points/presentation/schemas/patch-point-form.schema.ts
@@ -11,9 +11,14 @@ export const PatchPointFormSchema = z.object({
     .max(150, {
       message: MESSAGES_POINT['14.13']
     }),
-  description: z.string().max(150, {
-    message: MESSAGES_POINT['14.14']
-  }),
+  description: z
+    .string()
+    .max(150, {
+      message: MESSAGES_POINT['14.14']
+    })
+    .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val)),
   cfg: z.string()
 })
 

--- a/src/modules/points/presentation/schemas/post-point-form.schema.ts
+++ b/src/modules/points/presentation/schemas/post-point-form.schema.ts
@@ -10,9 +10,14 @@ export const PostPointFormSchema = z.object({
     .max(150, {
       message: MESSAGES_POINT['14.13']
     }),
-  description: z.string().max(150, {
-    message: MESSAGES_POINT['14.14']
-  }),
+  description: z
+    .string()
+    .max(150, {
+      message: MESSAGES_POINT['14.14']
+    })
+    .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val)),
   cfg: z.string()
 })
 

--- a/src/modules/users/domain/entities/user.entity.ts
+++ b/src/modules/users/domain/entities/user.entity.ts
@@ -9,6 +9,6 @@ export class UserEntity implements UserInterface {
     public position: string,
     public id?: number,
     public days_passwd_reg_deadline?: number,
-    public description?: string
+    public description?: string | null
   ) {}
 }

--- a/src/modules/users/domain/interfaces/user.interface.ts
+++ b/src/modules/users/domain/interfaces/user.interface.ts
@@ -6,5 +6,5 @@ export interface UserInterface {
   company: string
   position: string
   days_passwd_reg_deadline?: number
-  description?: string
+  description?: string | null
 }

--- a/src/modules/users/presentation/schemas/add-user-form.schema.ts
+++ b/src/modules/users/presentation/schemas/add-user-form.schema.ts
@@ -56,6 +56,8 @@ export const AddUserFormSchema = z.object({
       message: MESSAGES_USERS['5.32']
     })
     .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val))
 })
 
 export type AddUserFormType = z.infer<typeof AddUserFormSchema>

--- a/src/modules/users/presentation/schemas/edit-user-form.schema.ts
+++ b/src/modules/users/presentation/schemas/edit-user-form.schema.ts
@@ -33,10 +33,12 @@ export const EditUserFormSchema = z.object({
     .optional(),
   description: z
     .string()
-    .max(255, {
+    .max(150, {
       message: MESSAGES_USERS['5.32']
     })
     .optional()
+    .nullable()
+    .transform((val) => (!val || val.trim() === '' ? null : val))
 })
 
 export type EditUserFormType = z.infer<typeof EditUserFormSchema>


### PR DESCRIPTION
**Descrição:**

Ajustes de robustez e consistência na manipulação de campos opcionais e tratamento de erros em formulários e entidades relacionadas a perfis de permissão. Inclui correções para cenários de valores nulos e aprimoramentos nas interfaces utilizadas.

**Alterações:**

- **Refatorado:**

  - Inclusão do atributo `description` nas interfaces que permitem valores `null`  
  - Ajuste nas interfaces para tornar o atributo de descrição opcional na entidade de perfil de permissão  

- **Corrigido:**

  - Tratamento para campos em branco que retornavam `null`  
  - Bloqueio do envio de dados do formulário quando ocorre erro  
  - Ajuste no atributo opcional de descrição em entidades de perfil de permissão
